### PR TITLE
Remove dependency on `rustc-hash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,7 +746,6 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "rust-analyzer-salsa",
- "rustc-hash",
  "scarb-metadata",
  "scarb-proc-macro-server-types",
  "scarb-stable-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ itertools = "0.12.1"
 jod-thread = "0.1.2"
 lsp-server = "0.7.7"
 lsp-types = "=0.95.0"
-rustc-hash = "1.1.0"
 salsa = { package = "rust-analyzer-salsa", version = "0.17.0-pre.6" }
 scarb-metadata = "1.13"
 scarb-proc-macro-server-types = "0.1"

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -6,11 +6,11 @@
 // +-----------------------------------------------------+
 
 use std::any::TypeId;
+use std::collections::HashMap;
 
 use anyhow::Result;
 use lsp_server::{Notification, RequestId, Response};
 use lsp_types::notification::Notification as NotificationTrait;
-use rustc_hash::FxHashMap;
 use serde_json::Value;
 use tracing::error;
 
@@ -35,7 +35,7 @@ pub struct Responder(ClientSender);
 pub struct Requester<'s> {
     sender: ClientSender,
     next_request_id: i32,
-    response_handlers: FxHashMap<RequestId, ResponseBuilder<'s>>,
+    response_handlers: HashMap<RequestId, ResponseBuilder<'s>>,
 }
 
 impl Client<'_> {
@@ -46,7 +46,7 @@ impl Client<'_> {
             requester: Requester {
                 sender,
                 next_request_id: 1,
-                response_handlers: FxHashMap::default(),
+                response_handlers: HashMap::default(),
             },
         }
     }

--- a/src/server/client.rs
+++ b/src/server/client.rs
@@ -46,7 +46,7 @@ impl Client<'_> {
             requester: Requester {
                 sender,
                 next_request_id: 1,
-                response_handlers: HashMap::default(),
+                response_handlers: Default::default(),
             },
         }
     }


### PR DESCRIPTION
There is no hard data on any perf benefits of using it at the single place we do, and fewer dependencies is always a good improvement.