### PR TITLE
Refactor goto definition implementation

### DIFF
--- a/src/ide/hover/render/definition.rs
+++ b/src/ide/hover/render/definition.rs
@@ -9,7 +9,7 @@ use lsp_types::Hover;
 use crate::ide::hover::markdown_contents;
 use crate::ide::hover::render::markdown::{RULE, fenced_code_block};
 use crate::lang::db::AnalysisDatabase;
-use crate::lang::inspect::defs::{MemberDef, SymbolDef};
+use crate::lang::inspect::defs::SymbolDef;
 use crate::lang::lsp::ToLsp;
 
 /// Get declaration and documentation "definition" of an item referred by the given identifier.
@@ -52,15 +52,15 @@ pub fn definition(
             }
             md
         }
-        SymbolDef::Member(MemberDef { member, structure }) => {
+        SymbolDef::Member(member) => {
             let mut md = String::new();
 
             // Signature is the signature of the struct, so it makes sense that the definition
             // path is too.
-            md += &fenced_code_block(&structure.definition_path(db));
-            md += &fenced_code_block(&structure.signature(db));
+            md += &fenced_code_block(&member.structure().definition_path(db));
+            md += &fenced_code_block(&member.structure().signature(db));
 
-            if let Some(doc) = db.get_item_documentation((*member).into()) {
+            if let Some(doc) = db.get_item_documentation(member.member_id().into()) {
                 md += RULE;
                 md += &doc;
             }

--- a/src/ide/navigation/goto_definition.rs
+++ b/src/ide/navigation/goto_definition.rs
@@ -1,11 +1,8 @@
-use cairo_lang_filesystem::db::get_originating_location;
-use cairo_lang_filesystem::ids::FileId;
-use cairo_lang_filesystem::span::{TextPosition, TextSpan};
 use cairo_lang_utils::Upcast;
 use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location};
 
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
-use crate::lang::inspect::defs::find_definition;
+use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
+use crate::lang::inspect::defs::SymbolDef;
 use crate::lang::lsp::{LsProtoGroup, ToCairo, ToLsp};
 
 /// Get the definition location of a symbol at a given text document position.
@@ -15,41 +12,14 @@ pub fn goto_definition(
 ) -> Option<GotoDefinitionResponse> {
     let file = db.file_for_url(&params.text_document_position_params.text_document.uri)?;
     let position = params.text_document_position_params.position.to_cairo();
-    let (found_file, span) = get_definition_location(db, file, position)?;
-    let found_uri = db.url_for_file(found_file)?;
 
-    let range = span.position_in_file(db.upcast(), found_file)?.to_lsp();
-    Some(GotoDefinitionResponse::Scalar(Location { uri: found_uri, range }))
-}
-
-/// Returns the file id and span of the definition of an expression from its position.
-///
-/// # Arguments
-///
-/// * `db` - Preloaded compilation database
-/// * `uri` - Uri of the expression position
-/// * `position` - Position of the expression
-///
-/// # Returns
-///
-/// The [FileId] and [TextSpan] of the expression definition if found.
-fn get_definition_location(
-    db: &AnalysisDatabase,
-    file: FileId,
-    position: TextPosition,
-) -> Option<(FileId, TextSpan)> {
     let identifier = db.find_identifier_at_position(file, position)?;
+    let symbol = SymbolDef::find(db, &identifier)?;
+    let (found_file, span) = symbol.definition_location(db)?;
 
-    let syntax_db = db.upcast();
-    let node = db.find_syntax_node_at_position(file, position)?;
-    let lookup_items = db.collect_lookup_items_stack(&node)?;
-    let (_, stable_ptr) = find_definition(db, &identifier, &lookup_items)?;
-    let node = stable_ptr.lookup(syntax_db);
-    let found_file = stable_ptr.file_id(syntax_db);
-    let span = node.span_without_trivia(syntax_db);
-    let width = span.width();
-    let (file_id, mut span) =
-        get_originating_location(db.upcast(), found_file, span.start_only(), None);
-    span.end = span.end.add_width(width);
-    Some((file_id, span))
+    let found_uri = db.url_for_file(found_file)?;
+    let range = span.position_in_file(db.upcast(), found_file)?.to_lsp();
+    let location = Location { uri: found_uri, range };
+
+    Some(GotoDefinitionResponse::Scalar(location))
 }

--- a/tests/test_data/goto/inline_macros.txt
+++ b/tests/test_data/goto/inline_macros.txt
@@ -4,14 +4,10 @@
 test_goto_definition
 
 //! > cairo_code
-// FIXME(#116): This is wrong.
 fn main() {
     prin<caret>t!("Hello, world!");
 }
 
 //! > Goto definition #0
     prin<caret>t!("Hello, world!");
----
-<sel>fn main() {
-    print!("Hello, world!");
-}</sel>
+None

--- a/tests/test_data/goto/variables.txt
+++ b/tests/test_data/goto/variables.txt
@@ -45,6 +45,7 @@ fn main(<sel>abc: felt252</sel>, def: felt252) {
 test_goto_definition
 
 //! > cairo_code
+// FIXME(#120): This used to work before goto definition refactoring.
 fn foo(a: felt252) -> felt252 {
     let abc: felt252 = 0; // bad
     let c = |abc| { // good
@@ -56,5 +57,4 @@ fn foo(abc: felt252) {}
 
 //! > Goto definition #0
         ab<caret>c + 3
----
-    let c = |<sel>abc</sel>| { // good
+None


### PR DESCRIPTION
This code had a bunch of inconsistencies and unfixed smells
of the old codebase.
This PR attempts to streamline this implementation and prepare it for
_Find Usages_ functionality which will make use of this.

also, fix #116

---

**Stack**:
- #123
- #122
- #121 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*