### PR TITLE
Prepare tests for scarb metadata

### DIFF
--- a/tests/e2e/support/fixture.rs
+++ b/tests/e2e/support/fixture.rs
@@ -39,7 +39,7 @@ impl Fixture {
     }
 
     pub fn file_absolute_path(&self, path: impl AsRef<Path>) -> PathBuf {
-        self.t.child(path).path().to_owned()
+        self.t.child(path).canonicalize().unwrap().to_owned()
     }
 
     pub fn file_url(&self, path: impl AsRef<Path>) -> Url {


### PR DESCRIPTION
This fixes issues with symlink appearing in `scarb metadata`