### PR TITLE
Store `SymbolDef::ExprInlineMacro` as `SmolStr` instead of `String`

### DIFF
--- a/src/ide/hover/render/definition.rs
+++ b/src/ide/hover/render/definition.rs
@@ -46,7 +46,7 @@ pub fn definition(
         SymbolDef::Variable(var) => fenced_code_block(&var.signature(db)),
         SymbolDef::ExprInlineMacro(macro_name) => {
             let mut md = fenced_code_block(macro_name);
-            if let Some(doc) = db.inline_macro_plugins().get(macro_name)?.documentation() {
+            if let Some(doc) = db.inline_macro_plugins().get(macro_name.as_str())?.documentation() {
                 md += RULE;
                 md += &doc;
             }

--- a/src/lang/inspect/defs.rs
+++ b/src/lang/inspect/defs.rs
@@ -39,7 +39,7 @@ use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
 pub enum SymbolDef {
     Item(ItemDef),
     Variable(VariableDef),
-    ExprInlineMacro(String),
+    ExprInlineMacro(SmolStr),
     Member(MemberDef),
     Module(ModuleDef),
 }
@@ -55,7 +55,8 @@ impl SymbolDef {
                     parent
                         .parent()
                         .expect("Grandparent already exists")
-                        .get_text_without_trivia(db.upcast()),
+                        .get_text_without_trivia(db.upcast())
+                        .into(),
                 ));
             }
         }


### PR DESCRIPTION
**Stack**:
- #155
- #158
- #154
- #153
- #152 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*