### PR TITLE
Add missing `.canonicalize()` call in tests

### DIFF
--- a/tests/e2e/support/fixture.rs
+++ b/tests/e2e/support/fixture.rs
@@ -30,8 +30,8 @@ impl Fixture {
 
 /// Introspection methods.
 impl Fixture {
-    pub fn root_path(&self) -> &Path {
-        self.t.path()
+    pub fn root_path(&self) -> PathBuf {
+        self.t.path().canonicalize().unwrap()
     }
 
     pub fn root_url(&self) -> Url {

--- a/tests/e2e/support/normalize.rs
+++ b/tests/e2e/support/normalize.rs
@@ -14,7 +14,7 @@ pub fn normalize(fixture: impl AsRef<Fixture>, data: impl ToString) -> String {
 fn normalize_well_known_paths(fixture: &Fixture, data: String) -> String {
     let mut data = data
         .replace(&fixture.root_url().to_string(), "[ROOT_URL]")
-        .replace(&normalize_path(fixture.root_path()), "[ROOT]");
+        .replace(&normalize_path(&fixture.root_path()), "[ROOT]");
 
     if let Ok(pwd) = std::env::current_dir() {
         data = data.replace(&normalize_path(&pwd), "[PWD]");


### PR DESCRIPTION
Lack of it leads to fails on macOS due to extra `/private` segment in paths

---

**Stack**:
- #163
- #162 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*