### PR TITLE
Use const `cairo_project.toml` where possible

### DIFF
--- a/tests/e2e/analysis.rs
+++ b/tests/e2e/analysis.rs
@@ -3,6 +3,7 @@ use indoc::indoc;
 use lsp_types::{ExecuteCommandParams, lsp_request};
 use pretty_assertions::assert_eq;
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML;
 use crate::support::normalize::normalize;
 use crate::support::sandbox;
 
@@ -110,10 +111,7 @@ fn cairo_projects() {
 fn test_reload() {
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => indoc! {r#"
-                [crate_roots]
-                hello = "src"
-            "#},
+            "cairo_project.toml" => CAIRO_PROJECT_TOML,
             "src/lib.cairo" => "fn main() {}",
         }
     };

--- a/tests/e2e/completions.rs
+++ b/tests/e2e/completions.rs
@@ -2,6 +2,7 @@ use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use lsp_types::{CompletionParams, TextDocumentPositionParams, lsp_request};
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2024_07;
 use crate::support::cursor::peek_caret;
 use crate::support::{cursors, sandbox};
 
@@ -38,7 +39,7 @@ fn test_completions_text_edits(
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => inputs["cairo_project.toml"].clone(),
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2024_07,
             "src/lib.cairo" => cairo.clone(),
         }
     };

--- a/tests/e2e/goto_definition.rs
+++ b/tests/e2e/goto_definition.rs
@@ -1,11 +1,11 @@
 use cairo_lang_test_utils::parse_test_file::TestRunnerResult;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
-use indoc::indoc;
 use lsp_types::{
     ClientCapabilities, GotoCapability, GotoDefinitionParams, GotoDefinitionResponse,
     TextDocumentClientCapabilities, TextDocumentPositionParams, lsp_request,
 };
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2024_07;
 use crate::support::cursor::{peek_caret, peek_selection};
 use crate::support::{cursors, sandbox};
 
@@ -46,13 +46,7 @@ fn test_goto_definition(
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => indoc! {r#"
-                [crate_roots]
-                hello = "src"
-
-                [config.global]
-                edition = "2024_07"
-            "#},
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2024_07,
             "src/lib.cairo" => cairo.clone(),
         }
         client_capabilities = caps;

--- a/tests/e2e/hover.rs
+++ b/tests/e2e/hover.rs
@@ -5,6 +5,7 @@ use lsp_types::{
     MarkupKind, TextDocumentClientCapabilities, TextDocumentPositionParams, lsp_request,
 };
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2023_11;
 use crate::support::cursor::{peek_caret, peek_selection};
 use crate::support::{cursors, sandbox};
 
@@ -53,7 +54,7 @@ fn test_hover(
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => inputs["cairo_project.toml"].clone(),
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2023_11,
             "src/lib.cairo" => cairo.clone(),
         }
         client_capabilities = caps;

--- a/tests/e2e/macro_expand.rs
+++ b/tests/e2e/macro_expand.rs
@@ -3,6 +3,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_language_server::lsp::ext::ExpandMacro;
 use lsp_types::{TextDocumentIdentifier, TextDocumentPositionParams};
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2024_07;
 use crate::support::cursor::peek_caret;
 use crate::support::{cursors, sandbox};
 
@@ -26,7 +27,7 @@ fn test_macro_expand(
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => inputs["cairo_project.toml"].clone(),
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2024_07,
             "src/lib.cairo" => cairo.clone(),
         }
     };

--- a/tests/e2e/references.rs
+++ b/tests/e2e/references.rs
@@ -5,6 +5,7 @@ use lsp_types::{
     TextDocumentClientCapabilities, TextDocumentPositionParams, lsp_request,
 };
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2024_07;
 use crate::support::cursor::{peek_caret, peek_selection};
 use crate::support::{cursors, sandbox};
 
@@ -37,7 +38,7 @@ fn test_references(
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => inputs["cairo_project.toml"].clone(),
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2024_07,
             "src/lib.cairo" => cairo.clone(),
         }
         client_capabilities = caps;

--- a/tests/e2e/semantic_tokens.rs
+++ b/tests/e2e/semantic_tokens.rs
@@ -1,5 +1,6 @@
 use lsp_types::lsp_request;
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2023_11;
 use crate::support::sandbox;
 
 fn caps(base: lsp_types::ClientCapabilities) -> lsp_types::ClientCapabilities {
@@ -25,13 +26,7 @@ fn caps(base: lsp_types::ClientCapabilities) -> lsp_types::ClientCapabilities {
 fn highlights_multiline_tokens() {
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => r#"
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-"#,
+            "cairo_project.toml" => CAIRO_PROJECT_TOML_2023_11,
             "src/lib.cairo" => r#"
 fn main() {
     let _ = "

--- a/tests/e2e/support/cairo_project_toml.rs
+++ b/tests/e2e/support/cairo_project_toml.rs
@@ -1,0 +1,27 @@
+use indoc::indoc;
+
+pub const CAIRO_PROJECT_TOML: &str = indoc!(
+    r#"
+        [crate_roots]
+        hello = "src"
+    "#
+);
+
+pub const CAIRO_PROJECT_TOML_2024_07: &str = indoc!(
+    r#"
+        [crate_roots]
+        hello = "src"
+
+        [config.global]
+        edition = "2024_07"
+    "#
+);
+pub const CAIRO_PROJECT_TOML_2023_11: &str = indoc!(
+    r#"
+        [crate_roots]
+        hello = "src"
+
+        [config.global]
+        edition = "2023_11"
+    "#
+);

--- a/tests/e2e/support/mod.rs
+++ b/tests/e2e/support/mod.rs
@@ -1,3 +1,4 @@
+pub mod cairo_project_toml;
 pub mod client_capabilities;
 pub mod cursor;
 pub mod fixture;

--- a/tests/e2e/workspace_configuration.rs
+++ b/tests/e2e/workspace_configuration.rs
@@ -1,9 +1,9 @@
-use indoc::indoc;
 use lsp_server::Message;
 use lsp_types::lsp_request;
 use lsp_types::request::Request as _;
 use serde_json::json;
 
+use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML;
 use crate::support::sandbox;
 use crate::support::scarb::scarb_core_path;
 
@@ -28,10 +28,7 @@ fn relative_path_to_core() {
 
     let mut ls = sandbox! {
         files {
-            "cairo_project.toml" => indoc! {r#"
-                [crate_roots]
-                hello = "src"
-            "#},
+            "cairo_project.toml" => CAIRO_PROJECT_TOML,
             "src/lib.cairo" => r#"fn main() -> u8 { 42 }"#,
         }
         workspace_configuration = json!({

--- a/tests/test_data/completions/methods_text_edits.txt
+++ b/tests/test_data/completions/methods_text_edits.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_completions_text_edits(edit: true, insert: true)
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 mod hidden_trait {
     pub trait ATrait1<T> {
@@ -140,13 +133,6 @@ Text edit: use super::ATrait1;
 
 //! > test_runner_name
 test_completions_text_edits(edit: true, insert: true)
-
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
 
 //! > cairo_code
 mod hidden_trait {

--- a/tests/test_data/completions/module_items.txt
+++ b/tests/test_data/completions/module_items.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_completions_text_edits
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 mod helper_module {
     pub trait Trait1<T> {

--- a/tests/test_data/completions/structs.txt
+++ b/tests/test_data/completions/structs.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_completions_text_edits(detail: true)
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 mod some_module {
     pub struct Struct {

--- a/tests/test_data/hover/basic.txt
+++ b/tests/test_data/hover/basic.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 fn main() {
     let mut x<caret> = 5;
@@ -23,9 +16,9 @@ fn main() {
 }
 
 /// `add_two` documentation.
-fn add_t<caret>wo(x: u32) -> u32 { 
+fn add_t<caret>wo(x: u32) -> u32 {
   //! Adds 2 to an unsigned argument.
-  x + 2 
+  x + 2
 }
 
 /// Rectangle struct.
@@ -283,9 +276,9 @@ Calculate the area of the rectangle.
 
 //! > hover #14
 // = source context
-fn add_t<caret>wo(x: u32) -> u32 { 
+fn add_t<caret>wo(x: u32) -> u32 {
 // = highlight
-fn <sel>add_two</sel>(x: u32) -> u32 { 
+fn <sel>add_two</sel>(x: u32) -> u32 {
 // = popover
 ```cairo
 hello

--- a/tests/test_data/hover/literals.txt
+++ b/tests/test_data/hover/literals.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 const SOME_CONST: felt252 = 0x<caret>123;
 const WRONG_TYPE_CONST: u8 = 123_<caret>felt252;

--- a/tests/test_data/hover/missing_module.txt
+++ b/tests/test_data/hover/missing_module.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 m<caret>od<caret> mis<caret>sing;
 

--- a/tests/test_data/hover/partial.txt
+++ b/tests/test_data/hover/partial.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 fn main() {
     let mut xy<caret>z = unkn<caret>own_function();

--- a/tests/test_data/hover/paths.txt
+++ b/tests/test_data/hover/paths.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 /// some_module docstring.
 mod some_<caret>module {

--- a/tests/test_data/hover/starknet.txt
+++ b/tests/test_data/hover/starknet.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 use Balance::contr<caret>act_state_for_testing;
 

--- a/tests/test_data/hover/structs.txt
+++ b/tests/test_data/hover/structs.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 /// Docstring of Struct.
 struct Struct {

--- a/tests/test_data/hover/variables.txt
+++ b/tests/test_data/hover/variables.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_hover
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2023_11"
-
 //! > cairo_code
 fn main() {
     let ab<caret>c: felt252 = 0;

--- a/tests/test_data/macro_expand/attribute.txt
+++ b/tests/test_data/macro_expand/attribute.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_macro_expand
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 struct A {
     a: felt252

--- a/tests/test_data/macro_expand/derive.txt
+++ b/tests/test_data/macro_expand/derive.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_macro_expand
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 #[d<caret>erive(Drop,<caret> Serde)]<caret>
 struct <caret>A {

--- a/tests/test_data/macro_expand/empty.txt
+++ b/tests/test_data/macro_expand/empty.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_macro_expand
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 fn m<caret>ain() -> u3<caret>2 {
     // co<caret>mments

--- a/tests/test_data/macro_expand/simple_inline.txt
+++ b/tests/test_data/macro_expand/simple_inline.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_macro_expand
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 fn fib<caret>(mut n: u32) -> u32 {
   <caret>  pr<caret>intln!<caret>("some text")<caret>;<caret>

--- a/tests/test_data/references/fns.txt
+++ b/tests/test_data/references/fns.txt
@@ -3,13 +3,6 @@
 //! > test_runner_name
 test_references(include_declaration: false)
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 fn pow<caret>2(x: felt252) -> felt252 { x * x }
 
@@ -31,13 +24,6 @@ fn pow<caret>2(x: felt252) -> felt252 { x * x }
 
 //! > test_runner_name
 test_references(include_declaration: true)
-
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
 
 //! > cairo_code
 fn pow<caret>2(x: felt252) -> felt252 { x * x }
@@ -63,13 +49,6 @@ fn pow<caret>2(x: felt252) -> felt252 { x * x }
 //! > test_runner_name
 test_references(include_declaration: false)
 
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
-
 //! > cairo_code
 fn pow<caret>2(x: felt252) -> felt252 { x * x }
 
@@ -88,13 +67,6 @@ fn pow<caret>2(x: felt252) -> felt252 { x * x }
 
 //! > test_runner_name
 test_references(include_declaration: false)
-
-//! > cairo_project.toml
-[crate_roots]
-hello = "src"
-
-[config.global]
-edition = "2024_07"
 
 //! > cairo_code
 fn pow<caret>2(x: felt252) -> felt252 { x * x }


### PR DESCRIPTION
This will make it easier to move to more granular parametrized tests, as there will be no need for one extra parameter.