### PR TITLE
Replace first_ancestor_of_kind with parent_of_* fluent methods

### DIFF
--- a/src/ide/code_actions/create_module_file.rs
+++ b/src/ide/code_actions/create_module_file.rs
@@ -1,13 +1,13 @@
 use cairo_lang_defs::ids::{LanguageElementId, ModuleId};
 use cairo_lang_syntax::node::ast::{ItemModule, MaybeModuleBody};
-use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode};
+use cairo_lang_syntax::node::{SyntaxNode, Terminal};
 use lsp_types::{
     CodeAction, CodeActionKind, CreateFile, DocumentChangeOperation, DocumentChanges, ResourceOp,
     Url, WorkspaceEdit,
 };
 
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
+use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::syntax::SyntaxNodeExt;
 
 /// Code actions for missing module file.
 pub fn create_module_file(
@@ -15,8 +15,7 @@ pub fn create_module_file(
     node: SyntaxNode,
     mut url: Url,
 ) -> Option<CodeAction> {
-    let item_module = db.first_ancestor_of_kind(node.clone(), SyntaxKind::ItemModule)?;
-    let item_module = ItemModule::from_syntax_node(db, item_module);
+    let item_module = node.parent_of_type::<ItemModule>(db)?;
 
     if !matches!(item_module.body(db), MaybeModuleBody::None(_)) {
         return None;

--- a/src/ide/code_actions/expand_macro.rs
+++ b/src/ide/code_actions/expand_macro.rs
@@ -2,14 +2,15 @@ use cairo_lang_syntax::node::SyntaxNode;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use lsp_types::{CodeAction, Command};
 
-use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
+use crate::lang::db::AnalysisDatabase;
+use crate::lang::syntax::SyntaxNodeExt;
 
 /// Code actions for macro expansion.
 pub fn expand_macro(db: &AnalysisDatabase, node: SyntaxNode) -> Vec<CodeAction> {
     let mut result = vec![];
     let command = "cairo.expandMacro".to_owned();
 
-    if db.first_ancestor_of_kind(node.clone(), SyntaxKind::ExprInlineMacro).is_some() {
+    if node.parent_of_kind(db, SyntaxKind::ExprInlineMacro).is_some() {
         let title = "Expand macro recursively at caret".to_owned();
 
         result.push(CodeAction {
@@ -17,7 +18,7 @@ pub fn expand_macro(db: &AnalysisDatabase, node: SyntaxNode) -> Vec<CodeAction> 
             command: Some(Command { title, command, ..Default::default() }),
             ..Default::default()
         });
-    } else if db.first_ancestor_of_kind(node, SyntaxKind::Attribute).is_some() {
+    } else if node.parent_of_kind(db, SyntaxKind::Attribute).is_some() {
         let title = "Recursively expand macros for item at caret".to_owned();
 
         result.push(CodeAction {

--- a/src/ide/code_actions/fill_trait_members.rs
+++ b/src/ide/code_actions/fill_trait_members.rs
@@ -11,13 +11,13 @@ use cairo_lang_semantic::substitution::{
 };
 use cairo_lang_semantic::{ConcreteTraitId, GenericArgumentId, GenericParam, Parameter};
 use cairo_lang_syntax::node::ast::{ImplItem, ItemImpl, MaybeImplBody};
-use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Token, TypedSyntaxNode};
 use itertools::{Itertools, chain};
 use lsp_types::{CodeAction, CodeActionKind, CodeActionParams, Range, TextEdit, WorkspaceEdit};
 
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
+use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
 use crate::lang::lsp::ToLsp;
+use crate::lang::syntax::SyntaxNodeExt;
 
 /// Generates a completion adding all trait members that have not yet been specified.
 /// Functions are added with empty bodies, consts with placeholder values.
@@ -28,8 +28,7 @@ pub fn fill_trait_members(
 ) -> Option<CodeAction> {
     let file = db.find_module_file_containing_node(&node)?.file_id(db).ok()?;
 
-    let item_impl_node = db.first_ancestor_of_kind(node, SyntaxKind::ItemImpl)?;
-    let item_impl = ItemImpl::from_syntax_node(db, item_impl_node);
+    let item_impl = node.parent_of_type::<ItemImpl>(db)?;
 
     // Do not complete `impl`s without braces.
     let MaybeImplBody::Some(impl_body) = item_impl.body(db) else {

--- a/src/ide/completion/mod.rs
+++ b/src/ide/completion/mod.rs
@@ -14,6 +14,7 @@ use tracing::debug;
 use self::completions::{colon_colon_completions, dot_completions, generic_completions};
 use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
 use crate::lang::lsp::{LsProtoGroup, ToCairo};
+use crate::lang::syntax::SyntaxNodeExt;
 
 mod completions;
 mod mod_item;
@@ -155,12 +156,8 @@ fn completion_kind(
             }
         }
         SyntaxKind::TerminalLBrace | SyntaxKind::TerminalRBrace | SyntaxKind::TerminalComma => {
-            if let Some(constructor_node) =
-                db.first_ancestor_of_kind(node, SyntaxKind::ExprStructCtorCall)
-            {
-                return CompletionKind::StructConstructor(
-                    ast::ExprStructCtorCall::from_syntax_node(db, constructor_node),
-                );
+            if let Some(constructor) = node.parent_of_type::<ast::ExprStructCtorCall>(db) {
+                return CompletionKind::StructConstructor(constructor);
             }
         }
         // Show completions only if struct tail is separated from the cursor by a newline.
@@ -188,12 +185,8 @@ fn completion_kind(
             }
 
             if generate_completion {
-                if let Some(constructor_node) =
-                    db.first_ancestor_of_kind(node, SyntaxKind::ExprStructCtorCall)
-                {
-                    return CompletionKind::StructConstructor(
-                        ast::ExprStructCtorCall::from_syntax_node(db, constructor_node),
-                    );
+                if let Some(constructor) = node.parent_of_type::<ast::ExprStructCtorCall>(db) {
+                    return CompletionKind::StructConstructor(constructor);
                 }
             }
         }

--- a/src/ide/completion/mod_item.rs
+++ b/src/ide/completion/mod_item.rs
@@ -12,6 +12,7 @@ use lsp_types::{CompletionItem, CompletionItemKind, Url};
 
 use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
 use crate::lang::lsp::LsProtoGroup;
+use crate::lang::syntax::SyntaxNodeExt;
 
 pub fn mod_completions(
     db: &AnalysisDatabase,
@@ -22,7 +23,7 @@ pub fn mod_completions(
         db.first_ancestor_of_kind_respective_child(origin_node.clone(), SyntaxKind::ItemModule)?;
 
     // We are in nested mod, we should not show completions for file modules.
-    if db.first_ancestor_of_kind(node.parent().unwrap(), SyntaxKind::ItemModule).is_some() {
+    if node.parent_of_kind(db, SyntaxKind::ItemModule).is_some() {
         return Some(Vec::new());
     }
 

--- a/src/ide/hover/render/literal.rs
+++ b/src/ide/hover/render/literal.rs
@@ -13,8 +13,9 @@ use indoc::formatdoc;
 use lsp_types::Hover;
 
 use crate::ide::hover::markdown_contents;
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup, LsSyntaxGroup};
+use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
 use crate::lang::lsp::ToLsp;
+use crate::lang::syntax::SyntaxNodeExt;
 
 /// Narrows down [`SyntaxNode`] to [`TerminalLiteralNumber`], [`TerminalString`] or
 /// [`TerminalShortString`] if it represents some literal
@@ -69,8 +70,7 @@ fn find_type_in_function_context(
 fn find_type_in_const_declaration(db: &AnalysisDatabase, node: SyntaxNode) -> Option<String> {
     let module_file_id = db.find_module_file_containing_node(&node)?;
 
-    let const_node = db.first_ancestor_of_kind(node, SyntaxKind::ItemConstant)?;
-    let const_item = ItemConstant::from_syntax_node(db, const_node);
+    let const_item = node.parent_of_type::<ItemConstant>(db)?;
     let const_item_id = ConstantLongId(module_file_id, const_item.stable_ptr()).intern(db);
 
     Some(db.constant_const_type(const_item_id).ok()?.format(db))

--- a/src/ide/macros/expand.rs
+++ b/src/ide/macros/expand.rs
@@ -49,7 +49,7 @@ pub fn expand_macro(db: &AnalysisDatabase, params: &TextDocumentPositionParams) 
 
     let item_ast_node =
         db.first_ancestor_of_kind_respective_child(node.clone(), SyntaxKind::ModuleItemList);
-    let macro_ast_node = db.first_ancestor_of_kind(node.clone(), SyntaxKind::ExprInlineMacro);
+    let macro_ast_node = node.parent_of_kind(db, SyntaxKind::ExprInlineMacro);
 
     let (node_to_expand, top_level_macro_kind) = match (item_ast_node, macro_ast_node) {
         (Some(item_ast_node), Some(macro_ast_node)) => {

--- a/src/lang/db/syntax.rs
+++ b/src/lang/db/syntax.rs
@@ -75,11 +75,6 @@ pub trait LsSyntaxGroup: Upcast<dyn ParserGroup> {
         }
         None
     }
-
-    /// Finds first ancestor of a given kind.
-    fn first_ancestor_of_kind(&self, node: SyntaxNode, kind: SyntaxKind) -> Option<SyntaxNode> {
-        self.first_ancestor_of_kind_respective_child(node, kind).and_then(|node| node.parent())
-    }
 }
 
 impl<T> LsSyntaxGroup for T where T: Upcast<dyn ParserGroup> + ?Sized {}


### PR DESCRIPTION
I stole names from IntelliJ codebase. They're more concise and thus make method chains easier to read: https://github.com/JetBrains/intellij-community/blob/0ef4f9cb658d2d15a85cd0115bc4e9c97968e03d/platform/core-api/src/com/intellij/psi/util/psiTreeUtil.kt#L66-L78

---

**Stack**:
- #226
- #225 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*