### PR TITLE
Fix definition nodes for variables

### DIFF
--- a/src/ide/hover/render/definition.rs
+++ b/src/ide/hover/render/definition.rs
@@ -43,7 +43,7 @@ pub fn definition(
             md
         }
 
-        SymbolDef::Variable(var) => fenced_code_block(&var.signature(db)),
+        SymbolDef::Variable(var) => fenced_code_block(&var.signature(db)?),
         SymbolDef::ExprInlineMacro(macro_name) => {
             let mut md = fenced_code_block(macro_name);
             if let Some(doc) = db.inline_macro_plugins().get(macro_name.as_str())?.documentation() {

--- a/tests/e2e/find_references/vars.rs
+++ b/tests/e2e/find_references/vars.rs
@@ -146,7 +146,7 @@ fn param_via_use() {
         nu<caret>m * num
     }
     "#, @r"
-    fn pow(<sel=declaration>num: felt252</sel>) -> felt252 {
+    fn pow(<sel=declaration>num</sel>: felt252) -> felt252 {
         <sel>num</sel> * <sel>num</sel>
     }
     ")
@@ -160,7 +160,7 @@ fn param_captured_by_closure() {
         num * f(num)
     }
     "#, @r"
-    fn pow(<sel=declaration>num: felt252</sel>) -> felt252 {
+    fn pow(<sel=declaration>num</sel>: felt252) -> felt252 {
         let f = |x| <sel>num</sel> * x;
         <sel>num</sel> * f(<sel>num</sel>)
     }
@@ -188,6 +188,19 @@ fn var_in_trait_function_default_body() {
     }
     fn bar() {
         let foobar = 42;
+    }
+    ")
+}
+
+#[test]
+fn closure_param_via_use() {
+    test_transform!(find_references, r#"
+    fn main() {
+        let f = |abc: felt252| a<caret>bc + 1;
+    }
+    "#, @r"
+    fn main() {
+        let f = |<sel=declaration>abc</sel>: felt252| <sel>abc</sel> + 1;
     }
     ")
 }

--- a/tests/e2e/goto_definition/vars.rs
+++ b/tests/e2e/goto_definition/vars.rs
@@ -23,23 +23,22 @@ fn var_in_expr() {
 }
 
 #[test]
-fn fn_param_in_expr() {
+fn fn_param_via_expr() {
     test_transform!(goto_definition, r"
     fn main(abc: felt252, def: felt252) { // good
         let _ = ab<caret>c * 2;
     }
     fn foo(abc: felt252) {} // bad
     ", @r"
-    fn main(<sel>abc: felt252</sel>, def: felt252) { // good
+    fn main(<sel>abc</sel>: felt252, def: felt252) { // good
         let _ = abc * 2;
     }
     fn foo(abc: felt252) {} // bad
     ")
 }
 
-// FIXME(#120): This used to work before goto definition refactoring.
 #[test]
-fn closure_param_in_expr() {
+fn closure_param_via_expr() {
     test_transform!(goto_definition, r"
     fn foo(a: felt252) -> felt252 {
         let abc: felt252 = 0; // bad
@@ -47,7 +46,16 @@ fn closure_param_in_expr() {
             ab<caret>c + 3
         };
     }
-    
+
     fn foo(abc: felt252) {} // bad
-    ", @"none response")
+    ", @r"
+    fn foo(a: felt252) -> felt252 {
+        let abc: felt252 = 0; // bad
+        let c = |<sel>abc</sel>| { // good
+            abc + 3
+        };
+    }
+
+    fn foo(abc: felt252) {} // bad
+    ")
 }


### PR DESCRIPTION
This fixes goto definition for closure parameters (#120), but hovers still don't work, so this is not a complete fix.

---

**Stack**:
- #252
- #251
- #250
- #249
- #240
- #238 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*