### PR TITLE
Create a dedicated `SymbolDef::Variant` to fix finding references of enum variants

### DIFF
--- a/src/ide/hover/render/definition.rs
+++ b/src/ide/hover/render/definition.rs
@@ -57,10 +57,24 @@ pub fn definition(
 
             // Signature is the signature of the struct, so it makes sense that the definition
             // path is too.
-            md += &fenced_code_block(&member.structure().definition_path(db));
-            md += &fenced_code_block(&member.structure().signature(db));
+            md += &fenced_code_block(&member.struct_item().definition_path(db));
+            md += &fenced_code_block(&member.struct_item().signature(db));
 
             if let Some(doc) = db.get_item_documentation(member.member_id().into()) {
+                md += RULE;
+                md += &doc;
+            }
+            md
+        }
+        SymbolDef::Variant(variant) => {
+            let mut md = String::new();
+
+            // Signature is the signature of the enum, so it makes sense that the definition
+            // path is too.
+            md += &fenced_code_block(&variant.enum_item().definition_path(db));
+            md += &fenced_code_block(&variant.enum_item().signature(db));
+
+            if let Some(doc) = db.get_item_documentation(variant.variant_id().into()) {
                 md += RULE;
                 md += &doc;
             }

--- a/tests/e2e/find_references/enums.rs
+++ b/tests/e2e/find_references/enums.rs
@@ -8,18 +8,18 @@ fn enum_name() {
         Bar,
         Baz,
     }
-    
+
     fn main() {
         let foo = Foo::Bar;
         let foobar: Foo = foo;
     }
-    
+
     fn calc(foo: Foo) {}
-    
+
     mod rectangle {
         use super::Foo;
     }
-    
+
     mod trick {
         struct Foo {}
     }
@@ -46,24 +46,69 @@ fn enum_name() {
     ")
 }
 
-// FIXME(#129): Pattern should also be selected.
 #[test]
-fn enum_variants() {
+fn enum_variants_via_declaration() {
     test_transform!(find_references, r#"
-    enum Foo { Bar, Baz }
+    enum Foo { Ba<caret>r, Baz }
     fn main() {
-        let foo = Foo::Ba<caret>r;
+        let foo = Foo::Bar;
         match foo {
-            Foo::Bar => {}
+            Foo::Bar => {},
             _ => {}
         }
     }
     "#, @r"
     enum Foo { <sel=declaration>Bar</sel>, Baz }
     fn main() {
+        let foo = Foo::<sel>Bar</sel>;
+        match foo {
+            Foo::<sel>Bar</sel> => {},
+            _ => {}
+        }
+    }
+    ")
+}
+
+#[test]
+fn enum_variants_via_expr() {
+    test_transform!(find_references, r#"
+    enum Foo { Bar, Baz }
+    fn main() {
+        let foo = Foo::Ba<caret>r;
+        match foo {
+            Foo::Bar => {},
+            _ => {}
+        }
+    }
+    "#, @r"
+    enum Foo { <sel=declaration>Bar</sel>, Baz }
+    fn main() {
+        let foo = Foo::<sel>Bar</sel>;
+        match foo {
+            Foo::<sel>Bar</sel> => {},
+            _ => {}
+        }
+    }
+    ")
+}
+
+#[test]
+fn enum_variants_via_pattern() {
+    test_transform!(find_references, r#"
+    enum Foo { Bar, Baz }
+    fn main() {
         let foo = Foo::Bar;
         match foo {
-            Foo::Bar => {}
+            Foo::B<caret>ar => {},
+            _ => {}
+        }
+    }
+    "#, @r"
+    enum Foo { <sel=declaration>Bar</sel>, Baz }
+    fn main() {
+        let foo = Foo::<sel>Bar</sel>;
+        match foo {
+            Foo::<sel>Bar</sel> => {},
             _ => {}
         }
     }


### PR DESCRIPTION
Previously, `SymbolDef::Item` was used for enum variants. `ItemDef::name` returned the name of a **lookup item** related to the item, which for enum variants was **the enum**, not the variant itself. This caused a bug because usage finding uses the symbol's name as a text search needle, which made the algorithm attempt looking for references to the enum, yielding effectively no usage results.

fix #129 - this was the last FIXME comment related to that issue that was left, even though the bug eventually appeared to be completely unrelated.

---

**Stack**:
- #267
- #261
- #260
- #257 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*