### PR TITLE
Reduce the amount of parallelism consumed by our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,38 +14,29 @@ concurrency:
 
 jobs:
   build-test:
-    name: build test ${{ matrix.platform.name }}
-    runs-on: ${{ matrix.platform.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - name: linux x86-64
-            os: ubuntu-latest
+    name: build tests
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: nextest archive
-        run: cargo nextest archive --workspace --all-features --cargo-profile ci --archive-file 'nextest-archive-${{ matrix.platform.os }}.tar.zst'
+        run: cargo nextest archive --workspace --all-features --cargo-profile ci --archive-file 'nextest-archive.tar.zst'
       - uses: actions/upload-artifact@v4
         with:
-          name: nextest-archive-${{ matrix.platform.os }}
-          path: nextest-archive-${{ matrix.platform.os }}.tar.zst
+          name: nextest-archive
+          path: nextest-archive.tar.zst
 
   test:
-    name: test ${{ matrix.platform.name }} ${{ matrix.partition }}/8
-    runs-on: ${{ matrix.platform.os }}
+    name: test ${{ matrix.partition }}/4
+    runs-on: ubuntu-latest
     needs:
       - build-test
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - name: linux x86-64
-            os: ubuntu-latest
-        partition: [ 1, 2, 3, 4, 5, 6, 7, 8 ]
+        partition: [ 1, 2, 3, 4 ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -55,9 +46,9 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: actions/download-artifact@v4
         with:
-          name: nextest-archive-${{ matrix.platform.os }}
-      - name: nextest partition ${{ matrix.partition }}/8
-        run: cargo nextest run --partition 'count:${{ matrix.partition }}/8' --archive-file 'nextest-archive-${{ matrix.platform.os }}.tar.zst'
+          name: nextest-archive
+      - name: nextest partition ${{ matrix.partition }}/4
+        run: cargo nextest run --partition 'count:${{ matrix.partition }}/4' --archive-file 'nextest-archive.tar.zst'
 
   check:
     runs-on: ubuntu-latest
@@ -74,10 +65,4 @@ jobs:
         env:
           # Make sure CI fails on all warnings, including Clippy lints.
           RUSTDOCFLAGS: "-Dwarnings"
-
-  udeps:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
       - uses: bnjbvr/cargo-machete@main


### PR DESCRIPTION
- Merged `udeps` job into `check`,
- reduced the number of parallel test runs from 8 to 4,
- removed platform specs from matrices; we only run Linux anyway.