### PR TITLE
CI: Install `cargo-machete` using bininstall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,4 +65,5 @@ jobs:
         env:
           # Make sure CI fails on all warnings, including Clippy lints.
           RUSTDOCFLAGS: "-Dwarnings"
-      - uses: bnjbvr/cargo-machete@main
+      - uses: taiki-e/install-action@cargo-machete
+      - run: cargo machete


### PR DESCRIPTION
This avoids compiling cargo-machete on CI which speeds up the `check` job significantly.