### PR TITLE
Publish the `fixture` field from MockClient to increase readability

### DIFF
--- a/tests/e2e/code_actions/mod.rs
+++ b/tests/e2e/code_actions/mod.rs
@@ -53,7 +53,7 @@ fn quick_fix_general(cairo_code: &str, manifest_content: &str) -> String {
     assert_eq!(cursors.carets().len(), 1);
     let position = cursors.carets()[0];
 
-    let root_path = ls.as_ref().root_path().to_string_lossy().to_string();
+    let root_path = ls.fixture.root_path().to_string_lossy().to_string();
 
     let code_action_params = CodeActionParams {
         text_document: ls.doc_id("src/lib.cairo"),

--- a/tests/e2e/goto_definition/mod.rs
+++ b/tests/e2e/goto_definition/mod.rs
@@ -100,8 +100,8 @@ impl GotoDefinitionTest {
             .into_group_map()
             .into_iter()
             .map(|(url, ranges)| {
-                let path = self.ls.as_ref().url_path(&url).unwrap();
-                let cairo = self.ls.as_ref().read_file(&path);
+                let path = self.ls.fixture.url_path(&url).unwrap();
+                let cairo = self.ls.fixture.read_file(&path);
                 let selections = render_selections(&cairo, &ranges);
                 (path.to_string_lossy().to_string(), selections)
             })

--- a/tests/e2e/support/mock_client.rs
+++ b/tests/e2e/support/mock_client.rs
@@ -27,7 +27,7 @@ use serde_json::Value;
 /// Instead, the thread executing the server is being shut down and any running
 /// blocking tasks are given a small period of time to complete.
 pub struct MockClient {
-    fixture: Fixture,
+    pub fixture: Fixture,
     // Keeps last diagnostics generation for each file
     diagnostics: HashMap<Url, Vec<Diagnostic>>,
     req_id: RequestIdGenerator,
@@ -625,6 +625,7 @@ impl AsRef<Fixture> for MockClient {
         &self.fixture
     }
 }
+
 impl Drop for MockClient {
     fn drop(&mut self) {
         env::set_current_dir(self.starting_cwd.clone()).expect("Could not reset CWD")


### PR DESCRIPTION
The `impl AsRef<Fixture> for MockClient` was IMHO a bit overused in some places. Reading the `fixture` field directly reads much better.