### PR TITLE
Update Scarb version and enable previously ignored test

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-scarb nightly-2025-02-26
+scarb nightly-2025-03-12

--- a/tests/e2e/scarb/ignore_warnings_from_non_path_deps.rs
+++ b/tests/e2e/scarb/ignore_warnings_from_non_path_deps.rs
@@ -22,7 +22,6 @@ fn caps(base: ClientCapabilities) -> ClientCapabilities {
     }
 }
 
-#[ignore = "Uncomment after Scarb bump in CI"]
 #[test]
 fn test_ignore_warnings_from_non_path_deps() {
     let cairo_code = indoc! {r#"

--- a/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_dependency__removing_dependency.snap
+++ b/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_dependency__removing_dependency.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e/scarb/scarb_toml_change/removing_dependency.rs
+description: "// → a/Scarb.toml\n[package]\nname = \"a\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n[dependencies]\nb = { path = \"../b\" }\n\n// → a/src/lib.cairo\n\n\n// → b/Scarb.toml\n[package]\nname = \"b\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n// → b/src/lib.cairo\n"
 expression: "AnalyzedCratesResult { analyzed_crates, analyzed_crates_diff }"
 ---
 analyzed_crates = '''
@@ -95,8 +96,8 @@ analyzed_crates = '''
         version: Some(
             Version {
                 major: 2,
-                minor: 10,
-                patch: 1,
+                minor: 11,
+                patch: 2,
             },
         ),
         cfg_set: Some(

--- a/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_member__removing_member.snap
+++ b/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_member__removing_member.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e/scarb/scarb_toml_change/removing_member.rs
+description: "// → Scarb.toml\n[workspace]\nmembers = [\n    \"a\",\n    \"b\"\n]\n\n// → a/Scarb.toml\n[package]\nname = \"a\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n[dependencies]\nb = { path = \"../b\" }\n\n// → a/src/lib.cairo\n\n\n// → b/Scarb.toml\n[package]\nname = \"b\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n// → b/src/lib.cairo\n"
 expression: "AnalyzedCratesResult { analyzed_crates, analyzed_crates_diff }"
 ---
 analyzed_crates = '''
@@ -96,8 +97,8 @@ analyzed_crates = '''
         version: Some(
             Version {
                 major: 2,
-                minor: 10,
-                patch: 1,
+                minor: 11,
+                patch: 2,
             },
         ),
         cfg_set: Some(

--- a/tests/e2e/scarb/snapshots/e2e__scarb__simple_deps__simple_deps.snap
+++ b/tests/e2e/scarb/snapshots/e2e__scarb__simple_deps__simple_deps.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e/scarb/simple_deps.rs
+description: "// → a/Scarb.toml\n[package]\nname = \"a\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n[dependencies]\nb = { path = \"../b\" }\n\n// → a/src/lib.cairo\nuse b::Foo;\n\nfn main() {\n    let foo = Foo::Bar;\n    match foo {\n        Foo::Baz => {},\n        _ => {}\n    }\n}\n\n// → b/Scarb.toml\n[package]\nname = \"b\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n// → b/src/lib.cairo\npub enum Foo {\n    Bar,\n    Baz,\n}\n\nmod non_existent;"
 expression: "normalize(&ls, analyzed_crates)"
 ---
 # Analyzed Crates
@@ -94,8 +95,8 @@ expression: "normalize(&ls, analyzed_crates)"
         version: Some(
             Version {
                 major: 2,
-                minor: 10,
-                patch: 1,
+                minor: 11,
+                patch: 2,
             },
         ),
         cfg_set: Some(

--- a/tests/e2e/scarb/unmanaged_core.rs
+++ b/tests/e2e/scarb/unmanaged_core.rs
@@ -31,8 +31,8 @@ fn test_unmanaged_core_on_invalid_scarb_toml() {
             version: Some(
                 Version {
                     major: 2,
-                    minor: 10,
-                    patch: 1,
+                    minor: 11,
+                    patch: 2,
                 },
             ),
             cfg_set: None,

--- a/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates.snap
+++ b/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/e2e/analysis.rs
+description: "// → project1/cairo_project.toml\n[crate_roots]\nproject1 = \"src\"\n\n// → project1/src/lib.cairo\nfn main() {}\n\n// → project2/cairo_project.toml\n[crate_roots]\nproject2 = \"src\"\n\n// → project2/src/lib.cairo\nfn main() {}\n\n// → project2/subproject/cairo_project.toml\n[crate_roots]\nsubproject = \"src\"\n\n// → project2/subproject/src/lib.cairo\nfn main() {}"
 expression: "normalize(&ls, output)"
 ---
 # Analyzed Crates
@@ -12,8 +13,8 @@ expression: "normalize(&ls, output)"
         version: Some(
             Version {
                 major: 2,
-                minor: 10,
-                patch: 1,
+                minor: 11,
+                patch: 2,
             },
         ),
         cfg_set: None,


### PR DESCRIPTION
Bumped the Scarb version in `.tool-versions` to `nightly-2025-03-12`. Removed the `#[ignore]` attribute to re-enable a previously skipped test now compatible with the updated Scarb version.

fix #464