### PR TITLE
Don't traverse submodules for code lens on modules

### DIFF
--- a/src/ide/code_lens/tests.rs
+++ b/src/ide/code_lens/tests.rs
@@ -229,9 +229,11 @@ fn has_any_test(db: &AnalysisDatabase, module: ModuleId) -> bool {
 
     let Ok(modules) = db.module_submodules_ids(module) else { return false };
 
-    modules.iter().copied().map(ModuleId::Submodule).any(|submodule| {
-        collect_functions(db, submodule).is_empty().not() || has_any_test(db, submodule)
-    })
+    modules
+        .iter()
+        .copied()
+        .map(ModuleId::Submodule)
+        .any(|submodule| collect_functions(db, submodule).is_empty().not())
 }
 
 fn get_position(db: &AnalysisDatabase, file: FileId, ptr: SyntaxStablePtrId) -> Option<Position> {


### PR DESCRIPTION
Imo it's not desired if you have submodule with tests deeper in the module tree. That's also how intelijj does it