### PR TITLE
Fix double use completions in multi paths

### DIFF
--- a/src/ide/completion/mod.rs
+++ b/src/ide/completion/mod.rs
@@ -3,7 +3,7 @@ use attribute::derive::derive_completions;
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax::node::ast::{
-    self, Attribute, ExprStructCtorCall, ItemModule, TerminalIdentifier, UsePathLeaf, UsePathSingle,
+    self, Attribute, ExprStructCtorCall, ItemModule, TerminalIdentifier, UsePathSingle,
 };
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode};
@@ -103,15 +103,6 @@ pub fn complete(params: CompletionParams, db: &AnalysisDatabase) -> Option<Compl
 
         then {
             completions.extend(dot_completions);
-        }
-    );
-
-    if_chain!(
-        if let Some(leaf) = node.ancestor_of_type::<UsePathLeaf>(db);
-        if let Some(use_completions) = use_statement(db, ast::UsePath::Leaf(leaf), &ctx);
-
-        then {
-            completions.extend(use_completions);
         }
     );
 

--- a/tests/e2e/completions/module_items.rs
+++ b/tests/e2e/completions/module_items.rs
@@ -142,3 +142,48 @@ fn non_existent_module() {
     completions = []
     "#);
 }
+
+#[test]
+fn in_use_path_multi() {
+    test_transform!(test_completions_text_edits,"
+    mod module {
+        pub fn x() {}
+        pub fn y() {}
+    }
+
+    use module::{<caret>
+    ",@r#"
+    caret = """
+    use module::{<caret>
+    """
+
+    [[completions]]
+    completion_label = "x"
+
+    [[completions]]
+    completion_label = "y"
+    "#);
+}
+
+// FIXME(#673)
+#[test]
+fn in_use_path_multi_with_one_in_scope() {
+    test_transform!(test_completions_text_edits,"
+    mod module {
+        pub fn x() {}
+        pub fn y() {}
+    }
+
+    use module::{x, <caret>
+    ",@r#"
+    caret = """
+    use module::{x, <caret>
+    """
+
+    [[completions]]
+    completion_label = "x"
+
+    [[completions]]
+    completion_label = "y"
+    "#);
+}


### PR DESCRIPTION
`UsePathLeaf` case is always covered by `UsePathSingle` case