### PR TITLE
Fix resolution of type identifiers

### DIFF
--- a/tests/e2e/find_references/structs.rs
+++ b/tests/e2e/find_references/structs.rs
@@ -13,7 +13,6 @@ fn felt_in_struct() {
     ")
 }
 
-// FIXME(#435)
 #[test]
 fn usize_in_struct() {
     test_transform!(find_references, r#"
@@ -22,7 +21,7 @@ fn usize_in_struct() {
     "#, @r"
     // found several references in the core crate
     #[derive(Drop)]
-    struct Foo { field: usize }
+    struct Foo { field: <sel>usize</sel> }
     ")
 }
 

--- a/tests/e2e/find_references/types.rs
+++ b/tests/e2e/find_references/types.rs
@@ -194,23 +194,26 @@ fn test_extern_type_in_trait_associated_const_as_type_parameter() {
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_trait_generic_bound_as_type() {
     test_transform!(find_references, r#"
     trait Trait<T, +Into<u32<caret>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // found several references in the core crate
+    trait Trait<T, +Into<<sel>u32</sel>, T>> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_trait_generic_bound_as_type_parameter() {
     test_transform!(find_references, r#"
     trait Trait<T, +Into<Array<u32<caret>>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // found several references in the core crate
+    trait Trait<T, +Into<Array<<sel>u32</sel>>, T>> {}
+    ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_type_as_type() {
     test_transform!(find_references, r#"
@@ -221,16 +224,16 @@ fn test_extern_type_in_impl_associated_type_as_type() {
         type Type = u32<caret>;
     }
     "#, @r"
+    // found several references in the core crate
     trait Trait {
-        type <sel=declaration>Type</sel>;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = u32;
+        type Type = <sel>u32</sel>;
     }
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_type_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -241,16 +244,16 @@ fn test_extern_type_in_impl_associated_type_as_type_parameter() {
         type Type = Array<u32<caret>>;
     }
     "#, @r"
+    // found several references in the core crate
     trait Trait {
-        type <sel=declaration>Type</sel>;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = Array<u32>;
+        type Type = Array<<sel>u32</sel>>;
     }
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_const_as_type() {
     test_transform!(find_references, r#"
@@ -261,16 +264,16 @@ fn test_extern_type_in_impl_associated_const_as_type() {
         const Const: u32<caret> = 0x0;
     }
     "#, @r"
+    // found several references in the core crate
     trait Trait {
-        const <sel=declaration>Const</sel>: u32;
+        const Const: <sel>u32</sel>;
     }
     impl Impl of Trait {
-        const <sel>Const</sel>: u32 = 0x0;
+        const Const: <sel>u32</sel> = 0x0;
     }
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_const_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -281,31 +284,38 @@ fn test_extern_type_in_impl_associated_const_as_type_parameter() {
         const Const: Array<u32<caret>> = 0x0;
     }
     "#, @r"
+    // found several references in the core crate
     trait Trait {
-        const <sel=declaration>Const</sel>: u32;
+        const Const: <sel>u32</sel>;
     }
     impl Impl of Trait {
-        const <sel>Const</sel>: Array<u32> = 0x0;
+        const Const: Array<<sel>u32</sel>> = 0x0;
     }
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_impl_generic_bound_as_type() {
     test_transform!(find_references, r#"
     trait Trait<T, +Into<u32, T>> {}
     impl<T, +Into<u32<caret>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // found several references in the core crate
+    trait Trait<T, +Into<<sel>u32</sel>, T>> {}
+    impl<T, +Into<<sel>u32</sel>, T>> Impl of Trait<T> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_impl_generic_bound_as_type_parameter() {
     test_transform!(find_references, r#"
     trait Trait<T, +Into<u32, T>> {}
     impl<T, +Into<Array<u32<caret>>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // found several references in the core crate
+    trait Trait<T, +Into<<sel>u32</sel>, T>> {}
+    impl<T, +Into<Array<<sel>u32</sel>>, T>> Impl of Trait<T> {}
+    ")
 }
 
 #[test]
@@ -325,7 +335,6 @@ fn test_type_alias_in_use() {
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_alias_as_type() {
     test_transform!(find_references, r#"
@@ -333,13 +342,12 @@ fn test_type_alias_in_alias_as_type() {
     type SomeTypeAlias = Struct;
     type TypeAlias = SomeTypeAlias<caret>;
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    type TypeAlias = SomeTypeAlias;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    type TypeAlias = <sel>SomeTypeAlias</sel>;
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_alias_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -347,13 +355,12 @@ fn test_type_alias_in_alias_as_type_parameter() {
     type SomeTypeAlias = Struct;
     type TypeAlias = Array<SomeTypeAlias<caret>>;
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    type TypeAlias = Array<SomeTypeAlias>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    type TypeAlias = Array<<sel>SomeTypeAlias</sel>>;
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_variable_as_type() {
     test_transform!(find_references,
@@ -364,15 +371,14 @@ fn test_type_alias_in_variable_as_type() {
         let x: SomeTypeAlias<caret> = 0x0;
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     fn foo() {
-        let x: SomeTypeAlias = 0x0;
+        let x: <sel>SomeTypeAlias</sel> = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_variable_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -382,15 +388,14 @@ fn test_type_alias_in_variable_as_type_parameter() {
         let x: Array<SomeTypeAlias<caret>> = 0x0;
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     fn foo() {
-        let x: Array<SomeTypeAlias> = 0x0;
+        let x: Array<<sel>SomeTypeAlias</sel>> = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_function_argument_as_type() {
     test_transform!(find_references, r#"
@@ -398,13 +403,12 @@ fn test_type_alias_in_function_argument_as_type() {
     type SomeTypeAlias = Struct;
     fn foo(x: SomeTypeAlias<caret>) {}
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    fn foo(x: SomeTypeAlias) {}
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    fn foo(x: <sel>SomeTypeAlias</sel>) {}
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_function_argument_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -412,13 +416,12 @@ fn test_type_alias_in_function_argument_as_type_parameter() {
     type SomeTypeAlias = Struct;
     fn foo(x: Array<SomeTypeAlias<caret>>) {}
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    fn foo(x: Array<SomeTypeAlias>) {}
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    fn foo(x: Array<<sel>SomeTypeAlias</sel>>) {}
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_return_type_as_type() {
     test_transform!(find_references, r#"
@@ -426,13 +429,12 @@ fn test_type_alias_in_return_type_as_type() {
     type SomeTypeAlias = Struct;
     fn foo() -> SomeTypeAlias<caret> { 0x0 }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    fn foo() -> SomeTypeAlias { 0x0 }
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    fn foo() -> <sel>SomeTypeAlias</sel> { 0x0 }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_return_type_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -440,13 +442,12 @@ fn test_type_alias_in_return_type_as_type_parameter() {
     type SomeTypeAlias = Struct;
     fn foo() -> Array<SomeTypeAlias<caret>> { 0x0 }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    fn foo() -> Array<SomeTypeAlias> { 0x0 }
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    fn foo() -> Array<<sel>SomeTypeAlias</sel>> { 0x0 }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_struct_field_as_type() {
     test_transform!(find_references, r#"
@@ -457,14 +458,13 @@ fn test_type_alias_in_struct_field_as_type() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    struct <sel=declaration>Struct</sel> {
-        x: SomeTypeAlias
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    struct Struct {
+        x: <sel>SomeTypeAlias</sel>
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_struct_field_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -475,14 +475,13 @@ fn test_type_alias_in_struct_field_as_type_parameter() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = <sel>Struct</sel>;
-    struct <sel=declaration>Struct</sel> {
-        x: Array<SomeTypeAlias>
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    struct Struct {
+        x: Array<<sel>SomeTypeAlias</sel>>
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_turbofish_enum_as_type() {
     test_transform!(find_references, r#"
@@ -492,15 +491,14 @@ fn test_type_alias_in_turbofish_enum_as_type() {
         let x = Result::<SomeTypeAlias<caret>>::Err(());
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     fn foo() {
-        let x = Result::<SomeTypeAlias>::Err(());
+        let x = Result::<<sel>SomeTypeAlias</sel>>::Err(());
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_turbofish_enum_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -510,10 +508,10 @@ fn test_type_alias_in_turbofish_enum_as_type_parameter() {
         let x = Result::<Array<SomeTypeAlias<caret>>>::Err(());
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     fn foo() {
-        let x = Result::<Array<SomeTypeAlias>>::Err(());
+        let x = Result::<Array<<sel>SomeTypeAlias</sel>>>::Err(());
     }
     ")
 }
@@ -542,7 +540,6 @@ fn test_type_alias_in_trait_associated_type_as_type_parameter() {
     "#, @"none response")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_trait_associated_const_as_type() {
     test_transform!(find_references, r#"
@@ -552,15 +549,14 @@ fn test_type_alias_in_trait_associated_const_as_type() {
         const Const: SomeTypeAlias<caret>;
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        const Const: SomeTypeAlias;
+        const Const: <sel>SomeTypeAlias</sel>;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_trait_associated_const_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -570,35 +566,40 @@ fn test_type_alias_in_trait_associated_const_as_type_parameter() {
         const Const: Array<SomeTypeAlias<caret>>;
     }
     "#, @r"
-    struct <sel=declaration>Struct</sel> {}
-    type SomeTypeAlias = <sel>Struct</sel>;
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        const Const: Array<SomeTypeAlias>;
+        const Const: Array<<sel>SomeTypeAlias</sel>>;
     }
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_trait_generic_bound_as_type() {
     test_transform!(find_references, r#"
     struct Struct {}
     type SomeTypeAlias = Struct;
     trait Trait<T, +Into<SomeTypeAlias<caret>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    trait Trait<T, +Into<<sel>SomeTypeAlias</sel>, T>> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_trait_generic_bound_as_type_parameter() {
     test_transform!(find_references, r#"
     struct Struct {}
     type SomeTypeAlias = Struct;
     trait Trait<T, +Into<Array<SomeTypeAlias<caret>>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    trait Trait<T, +Into<Array<<sel>SomeTypeAlias</sel>>, T>> {}
+    ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_type_alias_in_impl_associated_type_as_type() {
     test_transform!(find_references, r#"
@@ -612,17 +613,16 @@ fn test_type_alias_in_impl_associated_type_as_type() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = Struct;
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        type <sel=declaration>Type</sel>;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = SomeTypeAlias;
+        type Type = <sel>SomeTypeAlias</sel>;
     }
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_type_alias_in_impl_associated_type_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -636,17 +636,16 @@ fn test_type_alias_in_impl_associated_type_as_type_parameter() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = Struct;
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        type <sel=declaration>Type</sel>;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = Array<SomeTypeAlias>;
+        type Type = Array<<sel>SomeTypeAlias</sel>>;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_impl_associated_const_as_type() {
     test_transform!(find_references, r#"
@@ -660,17 +659,16 @@ fn test_type_alias_in_impl_associated_const_as_type() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = Struct;
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        const <sel=declaration>Const</sel>: SomeTypeAlias;
+        const Const: <sel>SomeTypeAlias</sel>;
     }
     impl Impl of Trait {
-        const <sel>Const</sel>: SomeTypeAlias = 0x0;
+        const Const: <sel>SomeTypeAlias</sel> = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_impl_associated_const_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -684,17 +682,16 @@ fn test_type_alias_in_impl_associated_const_as_type_parameter() {
     }
     "#, @r"
     struct Struct {}
-    type SomeTypeAlias = Struct;
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
     trait Trait {
-        const <sel=declaration>Const</sel>: Array<SomeTypeAlias>;
+        const Const: Array<<sel>SomeTypeAlias</sel>>;
     }
     impl Impl of Trait {
-        const <sel>Const</sel>: Array<SomeTypeAlias> = 0x0;
+        const Const: Array<<sel>SomeTypeAlias</sel>> = 0x0;
     }
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_impl_generic_bound_as_type() {
     test_transform!(find_references, r#"
@@ -702,10 +699,14 @@ fn test_type_alias_in_impl_generic_bound_as_type() {
     type SomeTypeAlias = Struct;
     trait Trait<T, +Into<SomeTypeAlias, T>> {}
     impl<T, +Into<SomeTypeAlias<caret>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    trait Trait<T, +Into<<sel>SomeTypeAlias</sel>, T>> {}
+    impl<T, +Into<<sel>SomeTypeAlias</sel>, T>> Impl of Trait<T> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_impl_generic_bound_as_type_parameter() {
     test_transform!(find_references, r#"
@@ -713,5 +714,10 @@ fn test_type_alias_in_impl_generic_bound_as_type_parameter() {
     type SomeTypeAlias = Struct;
     trait Trait<T, +Into<SomeTypeAlias, T>> {}
     impl<T, +Into<Array<SomeTypeAlias<caret>>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {}
+    type <sel=declaration>SomeTypeAlias</sel> = Struct;
+    trait Trait<T, +Into<<sel>SomeTypeAlias</sel>, T>> {}
+    impl<T, +Into<Array<<sel>SomeTypeAlias</sel>>, T>> Impl of Trait<T> {}
+    ")
 }

--- a/tests/e2e/goto_definition/types.rs
+++ b/tests/e2e/goto_definition/types.rs
@@ -177,23 +177,26 @@ fn test_extern_type_in_trait_associated_const_as_type_parameter() {
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_trait_generic_bound_as_type() {
     test_transform!(goto_definition, r#"
     trait Trait<T, +Into<u32<caret>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_trait_generic_bound_as_type_parameter() {
     test_transform!(goto_definition, r#"
     trait Trait<T, +Into<Array<u32<caret>>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
+    ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_type_as_type() {
     test_transform!(goto_definition, r#"
@@ -205,17 +208,11 @@ fn test_extern_type_in_impl_associated_type_as_type() {
         type Type = u32<caret>;
     }
     "#, @r"
-    trait Trait {
-        type <sel>Type</sel>;
-    }
-
-    impl Impl of Trait {
-        type Type = u32;
-    }
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_type_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -226,16 +223,11 @@ fn test_extern_type_in_impl_associated_type_as_type_parameter() {
         type Type = Array<u32<caret>>;
     }
     "#, @r"
-    trait Trait {
-        type <sel>Type</sel>;
-    }
-    impl Impl of Trait {
-        type Type = Array<u32>;
-    }
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_const_as_type() {
     test_transform!(goto_definition, r#"
@@ -246,16 +238,11 @@ fn test_extern_type_in_impl_associated_const_as_type() {
         const Const: u32<caret> = 0x0;
     }
     "#, @r"
-    trait Trait {
-        const <sel>Const</sel>: u32;
-    }
-    impl Impl of Trait {
-        const Const: u32 = 0x0;
-    }
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_extern_type_in_impl_associated_const_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -266,31 +253,31 @@ fn test_extern_type_in_impl_associated_const_as_type_parameter() {
         const Const: Array<u32<caret>> = 0x0;
     }
     "#, @r"
-    trait Trait {
-        const <sel>Const</sel>: u32;
-    }
-    impl Impl of Trait {
-        const Const: Array<u32> = 0x0;
-    }
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_impl_generic_bound_as_type() {
     test_transform!(goto_definition, r#"
     trait Trait<T, +Into<u32, T>> {}
     impl<T, +Into<u32<caret>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_extern_type_in_impl_generic_bound_as_type_parameter() {
     test_transform!(goto_definition, r#"
     trait Trait<T, +Into<u32, T>> {}
     impl<T, +Into<Array<u32<caret>>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/integer.cairo
+    pub extern type <sel>u32</sel>;
+    ")
 }
 
 #[test]
@@ -303,31 +290,28 @@ fn test_builtin_alias_in_use() {
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_alias_as_type() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     type TypeAlias = u96<caret>
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_alias_as_type_parameter() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     type TypeAlias = Array<u96<caret>>
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_variable_as_type() {
     test_transform!(goto_definition, r#"
@@ -336,12 +320,11 @@ fn test_builtin_alias_in_variable_as_type() {
         let x: u96<caret> = 0x0;
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_variable_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -350,60 +333,55 @@ fn test_builtin_alias_in_variable_as_type_parameter() {
         let x: Array<u96<caret>> = 0x0;
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_function_argument_as_type() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     fn foo(x: u96<caret>) {}
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_function_argument_as_type_parameter() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     fn foo(x: Array<u96<caret>>) {}
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_return_type_as_type() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     fn foo() -> u96<caret> { 0x0 }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_return_type_as_type_parameter() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     fn foo() -> Array<u96<caret>> { 0x0 }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_struct_field_as_type() {
     test_transform!(goto_definition, r#"
@@ -412,12 +390,11 @@ fn test_builtin_alias_in_struct_field_as_type() {
         x: u96<caret>
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_struct_field_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -426,12 +403,11 @@ fn test_builtin_alias_in_struct_field_as_type_parameter() {
         x: Array<u96<caret>>
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_turbofish_enum_as_type() {
     test_transform!(goto_definition, r#"
@@ -440,12 +416,11 @@ fn test_builtin_alias_in_turbofish_enum_as_type() {
         let x = Result::<u96<caret>>::Err(());
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_turbofish_enum_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -454,8 +429,8 @@ fn test_builtin_alias_in_turbofish_enum_as_type_parameter() {
         let x = Result::<Array<u96<caret>>>::Err(());
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
@@ -481,7 +456,6 @@ fn test_builtin_alias_in_trait_associated_type_as_type_parameter() {
     "#, @"none response")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_trait_associated_const_as_type() {
     test_transform!(goto_definition, r#"
@@ -490,12 +464,11 @@ fn test_builtin_alias_in_trait_associated_const_as_type() {
         const Const: u96<caret>;
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_trait_associated_const_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -504,30 +477,33 @@ fn test_builtin_alias_in_trait_associated_const_as_type_parameter() {
         const Const: Array<u96<caret>>;
     }
     "#, @r"
-    // → core/src/internal/bounded_int.cairo
-    pub(crate) extern type <sel>BoundedInt</sel><const MIN: felt252, const MAX: felt252>;
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_builtin_alias_in_trait_generic_bound_as_type() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     trait Trait<T, +Into<u96<caret>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_builtin_alias_in_trait_generic_bound_as_type_parameter() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     trait Trait<T, +Into<Array<u96<caret>>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
+    ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_builtin_alias_in_impl_associated_type_as_type() {
     test_transform!(goto_definition, r#"
@@ -539,17 +515,11 @@ fn test_builtin_alias_in_impl_associated_type_as_type() {
         type Type = u96<caret>;
     }
     "#, @r"
-    use core::circuit::u96;
-    trait Trait {
-        type <sel>Type</sel>;
-    }
-    impl Impl of Trait {
-        type Type = u96;
-    }
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_builtin_alias_in_impl_associated_type_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -561,17 +531,11 @@ fn test_builtin_alias_in_impl_associated_type_as_type_parameter() {
         type Type = Array<u96<caret>>;
     }
     "#, @r"
-    use core::circuit::u96;
-    trait Trait {
-        type <sel>Type</sel>;
-    }
-    impl Impl of Trait {
-        type Type = Array<u96>;
-    }
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_impl_associated_const_as_type() {
     test_transform!(goto_definition, r#"
@@ -583,17 +547,11 @@ fn test_builtin_alias_in_impl_associated_const_as_type() {
         const Const: u96<caret> = 0x0;
     }
     "#, @r"
-    use core::circuit::u96;
-    trait Trait {
-        const <sel>Const</sel>: u96;
-    }
-    impl Impl of Trait {
-        const Const: u96 = 0x0;
-    }
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_builtin_alias_in_impl_associated_const_as_type_parameter() {
     test_transform!(goto_definition, r#"
@@ -605,32 +563,31 @@ fn test_builtin_alias_in_impl_associated_const_as_type_parameter() {
         const Const: Array<u96<caret>> = 0x0;
     }
     "#, @r"
-    use core::circuit::u96;
-    trait Trait {
-        const <sel>Const</sel>: u96;
-    }
-    impl Impl of Trait {
-        const Const: Array<u96> = 0x0;
-    }
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_builtin_alias_in_impl_generic_bound_as_type() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     trait Trait<T, +Into<u96, T>> {}
     impl<T, +Into<u96<caret>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_builtin_alias_in_impl_generic_bound_as_type_parameter() {
     test_transform!(goto_definition, r#"
     use core::circuit::u96;
     trait Trait<T, +Into<u96, T>> {}
     impl<T, +Into<Array<u96<caret>>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    // → core/src/circuit.cairo
+    pub type <sel>u96</sel> =
+    ")
 }

--- a/tests/e2e/rename/structs.rs
+++ b/tests/e2e/rename/structs.rs
@@ -13,13 +13,16 @@ fn felt_in_struct() {
     ")
 }
 
-// FIXME(#435)
 #[test]
 fn usize_in_struct() {
     test_transform!(rename, r#"
     #[derive(Drop)]
     struct Foo { field: usi<caret>ze }
-    "#, @"// found renames in the core crate")
+    "#, @r"
+    // found renames in the core crate
+    #[derive(Drop)]
+    struct Foo { field: RENAMED }
+    ")
 }
 
 #[test]

--- a/tests/e2e/rename/types.rs
+++ b/tests/e2e/rename/types.rs
@@ -18,7 +18,6 @@ fn test_type_alias_in_use() {
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_alias_as_type() {
     test_transform!(rename, r#"
@@ -26,13 +25,12 @@ fn test_type_alias_in_alias_as_type() {
     type TypeAlias = Struct;
     type AnotherTypeAlias = TypeAlias<caret>;
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    type AnotherTypeAlias = TypeAlias;
+    struct Struct {};
+    type RENAMED = Struct;
+    type AnotherTypeAlias = RENAMED;
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_alias_as_type_parameter() {
     test_transform!(rename, r#"
@@ -40,13 +38,12 @@ fn test_type_alias_in_alias_as_type_parameter() {
     type TypeAlias = Struct;
     type AnotherTypeAlias = Array<TypeAlias<caret>>;
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    type AnotherTypeAlias = Array<TypeAlias>;
+    struct Struct {};
+    type RENAMED = Struct;
+    type AnotherTypeAlias = Array<RENAMED>;
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_variable_as_type() {
     test_transform!(rename, r#"
@@ -56,15 +53,14 @@ fn test_type_alias_in_variable_as_type() {
         let x: TypeAlias<caret> = 0x0;
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     fn foo() {
-        let x: TypeAlias = 0x0;
+        let x: RENAMED = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_variable_as_type_parameter() {
     test_transform!(rename, r#"
@@ -74,15 +70,14 @@ fn test_type_alias_in_variable_as_type_parameter() {
         let x: Array<TypeAlias<caret>> = 0x0;
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     fn foo() {
-        let x: Array<TypeAlias> = 0x0;
+        let x: Array<RENAMED> = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_function_argument_as_type() {
     test_transform!(rename, r#"
@@ -90,13 +85,12 @@ fn test_type_alias_in_function_argument_as_type() {
     type TypeAlias = Struct;
     fn foo(x: TypeAlias<caret>) {}
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    fn foo(x: TypeAlias) {}
+    struct Struct {};
+    type RENAMED = Struct;
+    fn foo(x: RENAMED) {}
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_function_argument_as_type_parameter() {
     test_transform!(rename, r#"
@@ -104,13 +98,12 @@ fn test_type_alias_in_function_argument_as_type_parameter() {
     type TypeAlias = Struct;
     fn foo(x: Array<TypeAlias<caret>>) {}
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    fn foo(x: Array<TypeAlias>) {}
+    struct Struct {};
+    type RENAMED = Struct;
+    fn foo(x: Array<RENAMED>) {}
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_return_type_as_type() {
     test_transform!(rename, r#"
@@ -118,13 +111,12 @@ fn test_type_alias_in_return_type_as_type() {
     type TypeAlias = Struct;
     fn foo() -> TypeAlias<caret> { 0x0 }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    fn foo() -> TypeAlias { 0x0 }
+    struct Struct {};
+    type RENAMED = Struct;
+    fn foo() -> RENAMED { 0x0 }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_return_type_as_type_parameter() {
     test_transform!(rename, r#"
@@ -132,13 +124,12 @@ fn test_type_alias_in_return_type_as_type_parameter() {
     type TypeAlias = Struct;
     fn foo() -> Array<TypeAlias<caret>> { 0x0 }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
-    fn foo() -> Array<TypeAlias> { 0x0 }
+    struct Struct {};
+    type RENAMED = Struct;
+    fn foo() -> Array<RENAMED> { 0x0 }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_struct_field_as_type() {
     test_transform!(rename, r#"
@@ -149,14 +140,13 @@ fn test_type_alias_in_struct_field_as_type() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = RENAMED;
-    struct RENAMED {
-        x: TypeAlias
+    type RENAMED = Struct;
+    struct Struct {
+        x: RENAMED
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_struct_field_as_type_parameter() {
     test_transform!(rename, r#"
@@ -167,14 +157,13 @@ fn test_type_alias_in_struct_field_as_type_parameter() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = RENAMED;
-    struct RENAMED {
-        x: Array<TypeAlias>
+    type RENAMED = Struct;
+    struct Struct {
+        x: Array<RENAMED>
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_turbofish_enum_as_type() {
     test_transform!(rename, r#"
@@ -184,15 +173,14 @@ fn test_type_alias_in_turbofish_enum_as_type() {
         let x = Result::<TypeAlias<caret>>::Err(());
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     fn foo() {
-        let x = Result::<TypeAlias>::Err(());
+        let x = Result::<RENAMED>::Err(());
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_turbofish_enum_as_type_parameter() {
     test_transform!(rename, r#"
@@ -202,10 +190,10 @@ fn test_type_alias_in_turbofish_enum_as_type_parameter() {
         let x = Result::<Array<TypeAlias<caret>>>::Err(());
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     fn foo() {
-        let x = Result::<Array<TypeAlias>>::Err(());
+        let x = Result::<Array<RENAMED>>::Err(());
     }
     ")
 }
@@ -234,7 +222,6 @@ fn test_type_alias_in_trait_associated_type_as_type_parameter() {
     "#, @"none response")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_trait_associated_const_as_type() {
     test_transform!(rename, r#"
@@ -244,15 +231,14 @@ fn test_type_alias_in_trait_associated_const_as_type() {
         const Const: TypeAlias<caret>;
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     trait Trait {
-        const Const: TypeAlias;
+        const Const: RENAMED;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_trait_associated_const_as_type_parameter() {
     test_transform!(rename, r#"
@@ -262,35 +248,40 @@ fn test_type_alias_in_trait_associated_const_as_type_parameter() {
         const Const: Array<TypeAlias<caret>>;
     }
     "#, @r"
-    struct RENAMED {};
-    type TypeAlias = RENAMED;
+    struct Struct {};
+    type RENAMED = Struct;
     trait Trait {
-        const Const: Array<TypeAlias>;
+        const Const: Array<RENAMED>;
     }
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_trait_generic_bound_as_type() {
     test_transform!(rename, r#"
     struct Struct {};
     type TypeAlias = Struct;
     trait Trait<T, +Into<TypeAlias<caret>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {};
+    type RENAMED = Struct;
+    trait Trait<T, +Into<RENAMED, T>> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_trait_generic_bound_as_type_parameter() {
     test_transform!(rename, r#"
     struct Struct {};
     type TypeAlias = Struct;
     trait Trait<T, +Into<Array<TypeAlias<caret>>, T>> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {};
+    type RENAMED = Struct;
+    trait Trait<T, +Into<Array<RENAMED>, T>> {}
+    ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_type_alias_in_impl_associated_type_as_type() {
     test_transform!(rename, r#"
@@ -304,17 +295,16 @@ fn test_type_alias_in_impl_associated_type_as_type() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = Struct;
+    type RENAMED = Struct;
     trait Trait {
-        type RENAMED;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = TypeAlias;
+        type Type = RENAMED;
     }
     ")
 }
 
-// FIXME(#405)
 #[test]
 fn test_type_alias_in_impl_associated_type_as_type_parameter() {
     test_transform!(rename, r#"
@@ -328,17 +318,16 @@ fn test_type_alias_in_impl_associated_type_as_type_parameter() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = Struct;
+    type RENAMED = Struct;
     trait Trait {
-        type RENAMED;
+        type Type;
     }
     impl Impl of Trait {
-        type Type = Array<TypeAlias>;
+        type Type = Array<RENAMED>;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_impl_associated_const_as_type() {
     test_transform!(rename, r#"
@@ -352,17 +341,16 @@ fn test_type_alias_in_impl_associated_const_as_type() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = Struct;
+    type RENAMED = Struct;
     trait Trait {
-        const RENAMED: TypeAlias;
+        const Const: RENAMED;
     }
     impl Impl of Trait {
-        const RENAMED: TypeAlias = 0x0;
+        const Const: RENAMED = 0x0;
     }
     ")
 }
 
-// FIXME(#466)
 #[test]
 fn test_type_alias_in_impl_associated_const_as_type_parameter() {
     test_transform!(rename, r#"
@@ -376,17 +364,16 @@ fn test_type_alias_in_impl_associated_const_as_type_parameter() {
     }
     "#, @r"
     struct Struct {};
-    type TypeAlias = Struct;
+    type RENAMED = Struct;
     trait Trait {
-        const RENAMED: TypeAlias;
+        const Const: RENAMED;
     }
     impl Impl of Trait {
-        const RENAMED: Array<TypeAlias> = 0x0;
+        const Const: Array<RENAMED> = 0x0;
     }
     ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_impl_generic_bound_as_type() {
     test_transform!(rename, r#"
@@ -394,10 +381,14 @@ fn test_type_alias_in_impl_generic_bound_as_type() {
     type TypeAlias = Struct;
     trait Trait<T, +Into<TypeAlias, T>> {}
     impl<T, +Into<TypeAlias<caret>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {};
+    type RENAMED = Struct;
+    trait Trait<T, +Into<RENAMED, T>> {}
+    impl<T, +Into<RENAMED, T>> Impl of Trait<T> {}
+    ")
 }
 
-// FIXME(#51)
 #[test]
 fn test_type_alias_in_impl_generic_bound_as_type_parameter() {
     test_transform!(rename, r#"
@@ -405,5 +396,10 @@ fn test_type_alias_in_impl_generic_bound_as_type_parameter() {
     type TypeAlias = Struct;
     trait Trait<T, +Into<TypeAlias, T>> {}
     impl<T, +Into<Array<TypeAlias<caret>>, T>> Impl of Trait<T> {}
-    "#, @"none response")
+    "#, @r"
+    struct Struct {};
+    type RENAMED = Struct;
+    trait Trait<T, +Into<RENAMED, T>> {}
+    impl<T, +Into<Array<RENAMED>, T>> Impl of Trait<T> {}
+    ")
 }


### PR DESCRIPTION
Closes #51
Closes #405
Closes #435 
Closes #466
Closes #563
Closes #565

## Changes
* Type aliases are properly resolved to their definitions via `SymbolDef`
* LSP features work properly for type aliases and generic bounds, except for associated items in traits (#404)