### PR TITLE
Fix trait type `SymbolDef`

### DIFF
--- a/src/lang/db/semantic.rs
+++ b/src/lang/db/semantic.rs
@@ -4,7 +4,7 @@ use cairo_lang_defs::ids::{
     FreeFunctionLongId, ImplAliasLongId, ImplConstantDefLongId, ImplDefLongId, ImplFunctionLongId,
     ImplItemId, LanguageElementId, LookupItemId, ModuleFileId, ModuleId, ModuleItemId,
     ModuleTypeAliasLongId, StructLongId, TraitConstantLongId, TraitFunctionLongId, TraitImplLongId,
-    TraitItemId, TraitLongId, UseLongId, VarId,
+    TraitItemId, TraitLongId, TraitTypeLongId, UseLongId, VarId,
 };
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_semantic::Binding;
@@ -320,6 +320,15 @@ fn lookup_item_from_ast(
                 TraitImplLongId(
                     module_file_id,
                     ast::TraitItemImpl::from_syntax_node(db, node).stable_ptr(db),
+                )
+                .intern(db),
+            ))]
+        }
+        SyntaxKind::TraitItemType => {
+            vec![LookupItemId::TraitItem(TraitItemId::Type(
+                TraitTypeLongId(
+                    module_file_id,
+                    ast::TraitItemType::from_syntax_node(db, node).stable_ptr(db),
                 )
                 .intern(db),
             ))]

--- a/tests/e2e/find_references/traits.rs
+++ b/tests/e2e/find_references/traits.rs
@@ -407,6 +407,158 @@ fn dual_implementations_of_trait_via_trait_impl() {
 }
 
 #[test]
+fn impl_impl_via_usage() {
+    test_transform!(find_references, r#"
+    trait Bush {
+        fn bush() -> felt252;
+    }
+
+    trait BushTrait {
+        impl BushImplementation: Bush;
+    }
+
+    impl GeorgeBush of Bush {
+        fn bush() -> felt252 {
+            911
+        }
+    }
+
+    impl KateBush of Bush {
+        fn bush() -> felt252 {
+            1978
+        }
+    }
+
+    impl GeorgeImpl of BushTrait {
+        impl BushImplementation = GeorgeBush;
+    }
+    
+    impl KateImpl of BushTrait { 
+        impl BushImplementation = KateBush;
+    }
+
+
+    fn main() {
+        let v1 = GeorgeImpl::BushImplemen<caret>tation::bush();
+        let v2 = GeorgeImpl::BushImplementation::bush();
+        let v3 = KateImpl::BushImplementation::bush();
+        let v4 = KateImpl::BushImplementation::bush();
+    }
+    "#, @r"
+    trait Bush {
+        fn bush() -> felt252;
+    }
+
+    trait BushTrait {
+        impl BushImplementation: Bush;
+    }
+
+    impl GeorgeBush of Bush {
+        fn bush() -> felt252 {
+            911
+        }
+    }
+
+    impl KateBush of Bush {
+        fn bush() -> felt252 {
+            1978
+        }
+    }
+
+    impl GeorgeImpl of BushTrait {
+        impl <sel=declaration>BushImplementation</sel> = GeorgeBush;
+    }
+
+    impl KateImpl of BushTrait { 
+        impl BushImplementation = KateBush;
+    }
+
+
+    fn main() {
+        let v1 = GeorgeImpl::<sel>BushImplementation</sel>::bush();
+        let v2 = GeorgeImpl::<sel>BushImplementation</sel>::bush();
+        let v3 = KateImpl::BushImplementation::bush();
+        let v4 = KateImpl::BushImplementation::bush();
+    }
+    ")
+}
+
+#[test]
+fn impl_impl_via_trait() {
+    test_transform!(find_references, r#"
+    trait Bush {
+        fn bush() -> felt252;
+    }
+
+    trait BushTrait {
+        impl BushImple<caret>mentation: Bush;
+    }
+
+    impl GeorgeBush of Bush {
+        fn bush() -> felt252 {
+            911
+        }
+    }
+
+    impl KateBush of Bush {
+        fn bush() -> felt252 {
+            1978
+        }
+    }
+
+    impl GeorgeImpl of BushTrait {
+        impl BushImplementation = GeorgeBush;
+    }
+
+    impl KateImpl of BushTrait {
+        impl BushImplementation = KateBush;
+    }
+
+    fn main() {
+        let v1 = GeorgeImpl::BushImplementation::bush();
+        let v2 = GeorgeImpl::BushImplementation::bush();
+        let v3 = KateImpl::BushImplementation::bush();
+        let v4 = KateImpl::BushImplementation::bush();
+    }
+    "#, @r"
+    trait Bush {
+        fn bush() -> felt252;
+    }
+
+    trait BushTrait {
+        impl <sel=declaration>BushImplementation</sel>: Bush;
+    }
+
+    impl GeorgeBush of Bush {
+        fn bush() -> felt252 {
+            911
+        }
+    }
+
+    impl KateBush of Bush {
+        fn bush() -> felt252 {
+            1978
+        }
+    }
+
+    impl GeorgeImpl of BushTrait {
+        impl <sel>BushImplementation</sel> = GeorgeBush;
+    }
+
+    impl KateImpl of BushTrait {
+        impl <sel>BushImplementation</sel> = KateBush;
+    }
+
+    fn main() {
+        let v1 = GeorgeImpl::<sel>BushImplementation</sel>::bush();
+        let v2 = GeorgeImpl::<sel>BushImplementation</sel>::bush();
+        let v3 = KateImpl::<sel>BushImplementation</sel>::bush();
+        let v4 = KateImpl::<sel>BushImplementation</sel>::bush();
+    }
+    ")
+}
+
+#[test]
 fn associated_impl_member_const_usage() {
     test_transform!(find_references, r#"
     trait ConstCarryingTrait {

--- a/tests/e2e/find_references/traits.rs
+++ b/tests/e2e/find_references/traits.rs
@@ -322,7 +322,6 @@ fn dual_implementations_of_trait_via_trait_function() {
     ")
 }
 
-// FIXME(#170): This should return all of the below occurrences
 #[test]
 fn dual_implementations_of_trait_via_trait_type() {
     test_transform!(find_references, r#"
@@ -340,7 +339,22 @@ fn dual_implementations_of_trait_via_trait_type() {
         let v1: FooImpl::OverrideMe = 123;
         let v2: BarImpl::OverrideMe = 123;
     }
-    "#, @"none response")
+    "#, @r"
+    trait FooTrait {
+        type <sel=declaration>OverrideMe</sel>;
+    }
+    impl FooImpl of FooTrait {
+        type <sel>OverrideMe</sel> = u256;
+    }
+
+    impl BarImpl of FooTrait {
+        type <sel>OverrideMe</sel> = felt252;
+    }
+    fn main() {
+        let v1: FooImpl::<sel>OverrideMe</sel> = 123;
+        let v2: BarImpl::<sel>OverrideMe</sel> = 123;
+    }
+    ")
 }
 
 #[test]


### PR DESCRIPTION
Closes #170 

- [x] Take impl impls themselves into account (their usage must be found properly when referred to - just like type in this PR)