### PR TITLE
Redo proc macro cache

### DIFF
--- a/src/lang/proc_macros/client/plain_request_response.rs
+++ b/src/lang/proc_macros/client/plain_request_response.rs
@@ -2,7 +2,6 @@ use scarb_proc_macro_server_types::methods::expand::{
     ExpandAttributeParams, ExpandDeriveParams, ExpandInlineMacroParams,
 };
 
-use cairo_lang_macro::TextSpan;
 use scarb_proc_macro_server_types::scope::ProcMacroScope;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -11,7 +10,6 @@ pub struct PlainExpandAttributeParams {
     pub attr: String,
     pub args: String,
     pub item: String,
-    pub call_site: TextSpan,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -19,7 +17,6 @@ pub struct PlainExpandDeriveParams {
     pub context: ProcMacroScope,
     pub derives: Vec<String>,
     pub item: String,
-    pub call_site: TextSpan,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -27,7 +24,6 @@ pub struct PlainExpandInlineParams {
     pub context: ProcMacroScope,
     pub name: String,
     pub args: String,
-    pub call_site: TextSpan,
 }
 
 impl From<ExpandAttributeParams> for PlainExpandAttributeParams {
@@ -37,27 +33,16 @@ impl From<ExpandAttributeParams> for PlainExpandAttributeParams {
             attr: value.attr,
             args: value.args.to_string(),
             item: value.item.to_string(),
-            call_site: value.call_site,
         }
     }
 }
 impl From<ExpandDeriveParams> for PlainExpandDeriveParams {
     fn from(value: ExpandDeriveParams) -> Self {
-        Self {
-            context: value.context,
-            derives: value.derives,
-            item: value.item.to_string(),
-            call_site: value.call_site,
-        }
+        Self { context: value.context, derives: value.derives, item: value.item.to_string() }
     }
 }
 impl From<ExpandInlineMacroParams> for PlainExpandInlineParams {
     fn from(value: ExpandInlineMacroParams) -> Self {
-        Self {
-            context: value.context,
-            name: value.name,
-            args: value.args.to_string(),
-            call_site: value.call_site,
-        }
+        Self { context: value.context, name: value.name, args: value.args.to_string() }
     }
 }

--- a/src/lang/proc_macros/db.rs
+++ b/src/lang/proc_macros/db.rs
@@ -2,15 +2,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use scarb_proc_macro_server_types::conversions::token_stream_v2_to_v1;
-use scarb_proc_macro_server_types::methods::ProcMacroResult;
 use scarb_proc_macro_server_types::methods::expand::{
     ExpandAttributeParams, ExpandDeriveParams, ExpandInlineMacroParams,
 };
+use scarb_proc_macro_server_types::methods::{CodeOrigin, ProcMacroResult};
 
 use super::client::ServerStatus;
 use crate::lang::proc_macros::client::plain_request_response::{
     PlainExpandAttributeParams, PlainExpandDeriveParams, PlainExpandInlineParams,
 };
+use cairo_lang_macro::{TextSpan, TokenStream, TokenTree};
 
 /// A set of queries that enable access to proc macro client from compiler plugins
 /// `.generate_code()` methods.
@@ -75,9 +76,11 @@ fn get_stored_inline_macros_expansion(
 
 pub fn get_attribute_expansion(
     db: &dyn ProcMacroGroup,
-    params: ExpandAttributeParams,
+    mut params: ExpandAttributeParams,
 ) -> ProcMacroResult {
-    db.get_stored_attribute_expansion(params.clone().into()).unwrap_or_else(|| {
+    let stabilizer = SpansStabilizer::new(&mut params.call_site, &mut params.item);
+
+    let result = db.get_stored_attribute_expansion(params.clone().into()).unwrap_or_else(|| {
         let token_stream = params.item.clone();
 
         if let Some(client) = db.proc_macro_server_status().ready() {
@@ -89,14 +92,18 @@ pub fn get_attribute_expansion(
             diagnostics: Default::default(),
             code_mappings: None,
         }
-    })
+    });
+
+    stabilizer.apply_original_offsets_to_result(result)
 }
 
 pub fn get_derive_expansion(
     db: &dyn ProcMacroGroup,
-    params: ExpandDeriveParams,
+    mut params: ExpandDeriveParams,
 ) -> ProcMacroResult {
-    db.get_stored_derive_expansion(params.clone().into()).unwrap_or_else(|| {
+    let stabilizer = SpansStabilizer::new(&mut params.call_site, &mut params.item);
+
+    let result = db.get_stored_derive_expansion(params.clone().into()).unwrap_or_else(|| {
         if let Some(client) = db.proc_macro_server_status().ready() {
             client.request_derives(params);
         }
@@ -107,25 +114,114 @@ pub fn get_derive_expansion(
             diagnostics: Default::default(),
             code_mappings: None,
         }
-    })
+    });
+
+    stabilizer.apply_original_offsets_to_result(result)
 }
 
 pub fn get_inline_macros_expansion(
     db: &dyn ProcMacroGroup,
-    params: ExpandInlineMacroParams,
+    mut params: ExpandInlineMacroParams,
 ) -> ProcMacroResult {
-    db.get_stored_inline_macros_expansion(params.clone().into()).unwrap_or_else(|| {
-        // We can't return the original node because it will make us fall into infinite recursion.
-        let unit = "()".to_string();
+    let stabilizer = SpansStabilizer::new(&mut params.call_site, &mut params.args);
 
-        if let Some(client) = db.proc_macro_server_status().ready() {
-            client.request_inline_macros(params);
+    let result =
+        db.get_stored_inline_macros_expansion(params.clone().into()).unwrap_or_else(|| {
+            // We can't return the original node because it will make us fall into infinite recursion.
+            let unit = "()".to_string();
+
+            if let Some(client) = db.proc_macro_server_status().ready() {
+                client.request_inline_macros(params);
+            }
+
+            ProcMacroResult {
+                token_stream: cairo_lang_macro_v1::TokenStream::new(unit),
+                diagnostics: Default::default(),
+                code_mappings: None,
+            }
+        });
+
+    stabilizer.apply_original_offsets_to_result(result)
+}
+
+/// When storing a procedural macro result, parameters are used as the cache key.
+/// However, this approach is insufficient because the macro result's token stream may include spans from the input token stream.
+/// Input spans can change if, for example, a user makes edits earlier in the file than where the item is defined.
+/// This might result in situations where the input token stream remains identical, but its spans have shifted, triggering unnecessary macro recalculations.
+/// Such recalculations can lead to failures in expanding macros due to a new 'analysis in progress' status.
+/// To prevent this, we adjust the input parameters (input token stream, call site) by setting their offsets to stable values (0 for the token stream and [`Self::STABLE_CALL_SITE_START`] for the call site).
+/// We then submit the request using these adjusted parameters as usual for caching.
+/// Upon receiving a response, we modify the result (both token stream and call site) to replace spans using the original offsets and call site, as handled by [`Self::apply_original_offset_to_span`].
+struct SpansStabilizer {
+    original_call_site: TextSpan,
+    original_item_offset: u32,
+}
+
+impl SpansStabilizer {
+    /// Arbitrary number that must be bigger than anyting macro should produce.
+    ///
+    /// We use trick here to set call site for const value, then all mappings and diagnostics that points to this offest will be remaped to call site, instead of being increased by item offset.
+    /// This is high enough to make sure there should be no collision with item mappings and diagnostics.
+    const STABLE_CALL_SITE_START: u32 = 3000000000;
+
+    pub fn new(call_site: &mut TextSpan, token_stream: &mut TokenStream) -> Self {
+        let stable_call_site = TextSpan {
+            // Hack: Use arbitrary high number for call site, this way there should be no collision with item.
+            start: Self::STABLE_CALL_SITE_START,
+            end: call_site.end - call_site.start,
+        };
+
+        let original_call_site = std::mem::replace(call_site, stable_call_site);
+
+        // First token start is offset of whole item.
+        let original_item_offset = match &token_stream.tokens[0] {
+            TokenTree::Ident(token) => token.span.start,
+        };
+
+        // Reduce all tokens spans by item offset.
+        for token in &mut token_stream.tokens {
+            match token {
+                TokenTree::Ident(token) => {
+                    token.span.start -= original_item_offset;
+                    token.span.end -= original_item_offset;
+                }
+            }
         }
 
-        ProcMacroResult {
-            token_stream: cairo_lang_macro_v1::TokenStream::new(unit),
-            diagnostics: Default::default(),
-            code_mappings: None,
+        Self { original_call_site, original_item_offset }
+    }
+
+    pub fn apply_original_offsets_to_result(self, mut result: ProcMacroResult) -> ProcMacroResult {
+        if let Some(code_mappings) = &mut result.code_mappings {
+            for mapping in code_mappings.iter_mut() {
+                match mapping.origin {
+                    CodeOrigin::Start(_) => {
+                        // Should be unreachable
+                    }
+                    CodeOrigin::Span(ref mut span) | CodeOrigin::CallSite(ref mut span) => {
+                        self.apply_original_offset_to_span(span);
+                    }
+                };
+            }
         }
-    })
+
+        for diagnostic in &mut result.diagnostics {
+            if let Some(span) = &mut diagnostic.span {
+                self.apply_original_offset_to_span(span);
+            }
+        }
+
+        result
+    }
+
+    fn apply_original_offset_to_span(&self, span: &mut TextSpan) {
+        if span.start == Self::STABLE_CALL_SITE_START {
+            *span = self.original_call_site.clone();
+        } else {
+            *span = TextSpan {
+                start: span.start + self.original_item_offset,
+                end: span.end + self.original_item_offset,
+            };
+        }
+    }
 }

--- a/src/lang/proc_macros/plugins/downcast.rs
+++ b/src/lang/proc_macros/plugins/downcast.rs
@@ -28,7 +28,6 @@ mod unsafe_downcast_ref_tests {
     use crate::lang::db::AnalysisDatabase;
     use crate::lang::proc_macros::client::plain_request_response::PlainExpandAttributeParams;
     use crate::lang::proc_macros::db::ProcMacroGroup;
-    use cairo_lang_macro::TextSpan;
     use cairo_lang_macro_v1::TokenStream;
     use cairo_lang_syntax::node::db::SyntaxGroup;
     use scarb_proc_macro_server_types::methods::ProcMacroResult;
@@ -47,7 +46,6 @@ mod unsafe_downcast_ref_tests {
             attr: "asd".to_string(),
             args: "asd".to_string(),
             item: "asd".to_string(),
-            call_site: TextSpan { start: 0, end: 0 },
         };
         let output = ProcMacroResult {
             token_stream: TokenStream::new("asd".to_string()),


### PR DESCRIPTION
This way if we change code before expanded item we will not have to recalculate expansions again. This also allows new expand macro command to work properly.

---

**Stack**:
- #604
- #726 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*