### PR TITLE
Fix get resultants

### DIFF
--- a/src/lang/db/semantic.rs
+++ b/src/lang/db/semantic.rs
@@ -538,6 +538,13 @@ fn find_generated_nodes(
         let mut new_nodes: OrderedHashSet<_> = Default::default();
 
         for token in file_syntax.tokens(db) {
+            // Skip end of the file terminal, which is also a syntax tree leaf.
+            // As `ModuleItemList` and `TerminalEndOfFile` have the same parent,
+            // which is the `SyntaxFile`, so we don't want to take the `SyntaxFile`
+            // as an additional resultant.
+            if token.kind(db) == SyntaxKind::TerminalEndOfFile {
+                continue;
+            }
             let nodes: Vec<_> = token
                 .ancestors_with_self(db)
                 .map_while(|new_node| {


### PR DESCRIPTION
`.tokens` function also return `SyntaxKind::TerminalEndOfFile`:

```
└── root (kind: SyntaxFile)
    ├── items (kind: ModuleItemList)
    │   |
    |   ...
    └── eof (kind: TokenEndOfFile).
```

which in case like this: 

Macro:
```
#[attribute_macro]
pub fn simple_attribute_macro_v2(_args: TokenStream, item: TokenStream) -> ProcMacroResult {
    let ts = quote! {
        #item

        fn generated_function_v2() {}
    };
    ProcMacroResult::new(ts)
}
```

Code:
```
#[simple_attribute_macro_v2]
fn foo() { }

fn main() { }
```

Return 2 resultants refering to the same mapping:
- `SyntaxFile` that comes from the search beginning with `TokenEndOfFile`.
- `ModuleItemList` which comes from the search beginning from any leaf inside the `ModuleItemList`