### PR TITLE
Make assert inline macro plugins return `AssertMacros` instead of `CairoTest` in `ViewAnalyzedCrates`

### DIFF
--- a/src/project/builtin_plugins.rs
+++ b/src/project/builtin_plugins.rs
@@ -121,8 +121,8 @@ impl MacroPlugin for CairoRunPlugin {
 /// are private and cannot be accessed outside the compiler.
 static PLUGIN_TYPE_IDS: LazyLock<HashMap<TypeId, BuiltinPlugin>> = LazyLock::new(|| {
     chain!(
-        plugin_type_ids(test_assert_suite()).map(|id| (id, BuiltinPlugin::AssertMacros)),
         plugin_type_ids(test_plugin_suite()).map(|id| (id, BuiltinPlugin::CairoTest)),
+        plugin_type_ids(test_assert_suite()).map(|id| (id, BuiltinPlugin::AssertMacros)),
         plugin_type_ids(cairo_run_plugin_suite()).map(|id| (id, BuiltinPlugin::CairoRun)),
         plugin_type_ids(executable_plugin_suite()).map(|id| (id, BuiltinPlugin::Executable)),
         plugin_type_ids(starknet_plugin_suite()).map(|id| (id, BuiltinPlugin::Starknet)),

--- a/tests/e2e/analysis.rs
+++ b/tests/e2e/analysis.rs
@@ -60,3 +60,27 @@ fn test_reload() {
 
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn assert_macros_with_no_cairo_test() {
+    let mut ls = sandbox! {
+        files {
+            "Scarb.toml" => indoc! (r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2024_07"
+
+                [dependencies]
+                assert_macros = "2"
+            "#),
+            "src/lib.cairo" => "fn main() {}",
+        }
+    };
+
+    ls.open_all_cairo_files_and_wait_for_project_update();
+
+    let output = ls.send_request::<lsp::ext::ViewAnalyzedCrates>(());
+
+    insta::assert_snapshot!("view_analyzed_crates_assert_macros", normalize(&ls, output));
+}

--- a/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_dependency__removing_dependency.snap
+++ b/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_dependency__removing_dependency.snap
@@ -121,6 +121,7 @@ analyzed_crates = '''
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest"
     ]

--- a/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_member__removing_member.snap
+++ b/tests/e2e/scarb/scarb_toml_change/snapshots/e2e__scarb__scarb_toml_change__removing_member__removing_member.snap
@@ -122,6 +122,7 @@ analyzed_crates = '''
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest"
     ]

--- a/tests/e2e/scarb/snapshots/e2e__scarb__opening_multiple_workspaces__opening_dependency_first.snap
+++ b/tests/e2e/scarb/snapshots/e2e__scarb__opening_multiple_workspaces__opening_dependency_first.snap
@@ -41,6 +41,7 @@ analyzed_crates = '''
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest"
     ]
@@ -88,6 +89,7 @@ analyzed_crates = '''
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "CairoTest"
     ]
   }
@@ -163,7 +165,7 @@ analyzed_crates_diff = '''
        "user_defined_inline_macros": false
      }
    },
-@@ -45,30 +49,34 @@
+@@ -46,30 +50,34 @@
    "name": "dep",
    "source_paths": [
      "[ROOT]/dep/src/lib.cairo"
@@ -198,7 +200,7 @@ analyzed_crates_diff = '''
          "discriminator": "dev_dep 0.1.0 (path+[ROOT_URL]dev_dep/Scarb.toml)"
        }
      },
-@@ -108,16 +116,58 @@
+@@ -110,16 +118,58 @@
        },
        "dev_dep": {
          "discriminator": "dev_dep 0.1.0 (path+[ROOT_URL]dev_dep/Scarb.toml)"

--- a/tests/e2e/scarb/snapshots/e2e__scarb__simple_deps__simple_deps.snap
+++ b/tests/e2e/scarb/snapshots/e2e__scarb__simple_deps__simple_deps.snap
@@ -120,6 +120,7 @@ expression: "normalize(&ls, analyzed_crates)"
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest"
     ]

--- a/tests/e2e/scarb/unmanaged_core.rs
+++ b/tests/e2e/scarb/unmanaged_core.rs
@@ -45,6 +45,7 @@ fn test_unmanaged_core_on_invalid_scarb_toml() {
       "linter_configuration": "Off",
       "plugins": {
         "builtin_plugins": [
+          "AssertMacros",
           "Executable",
           "CairoTest"
         ]

--- a/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates.snap
+++ b/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates.snap
@@ -27,6 +27,7 @@ expression: "normalize(&ls, output)"
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest"
     ]
@@ -54,6 +55,7 @@ expression: "normalize(&ls, output)"
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest",
       "Starknet"
@@ -82,6 +84,7 @@ expression: "normalize(&ls, output)"
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest",
       "Starknet"
@@ -110,6 +113,7 @@ expression: "normalize(&ls, output)"
   "linter_configuration": "Off",
   "plugins": {
     "builtin_plugins": [
+      "AssertMacros",
       "Executable",
       "CairoTest",
       "Starknet"

--- a/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates_assert_macros.snap
+++ b/tests/e2e/snapshots/e2e__analysis__view_analyzed_crates_assert_macros.snap
@@ -1,0 +1,92 @@
+---
+source: tests/e2e/analysis.rs
+description: "// → Scarb.toml\n[package]\nname = \"a\"\nversion = \"0.1.0\"\nedition = \"2024_07\"\n\n[dependencies]\nassert_macros = \"2\"\n\n// → src/lib.cairo\nfn main() {}"
+expression: "normalize(&ls, output)"
+---
+# Analyzed Crates
+---
+```json
+{
+  "name": "a",
+  "source_paths": [
+    "[ROOT]/src/lib.cairo"
+  ],
+  "settings": {
+    "name": "a",
+    "edition": "2024_07",
+    "version": "0.1.0",
+    "cfg_set": [
+      [
+        "target",
+        "lib"
+      ],
+      [
+        "target",
+        "test"
+      ],
+      "test"
+    ],
+    "dependencies": {
+      "a": {
+        "discriminator": "a 0.1.0 (path+[ROOT_URL]Scarb.toml)"
+      },
+      "core": {
+        "discriminator": null
+      }
+    },
+    "experimental_features": {
+      "negative_impls": false,
+      "associated_item_constraints": false,
+      "coupons": false,
+      "user_defined_inline_macros": false
+    }
+  },
+  "linter_configuration": "Off",
+  "plugins": {
+    "builtin_plugins": [
+      "AssertMacros"
+    ]
+  }
+}
+
+{
+  "name": "core",
+  "source_paths": [
+    "[SCARB_REGISTRY_STD]/core/src/lib.cairo"
+  ],
+  "settings": {
+    "name": "core",
+    "edition": "2024_07",
+    "version": "2.11.4",
+    "cfg_set": [
+      [
+        "target",
+        "lib"
+      ],
+      [
+        "target",
+        "test"
+      ]
+    ],
+    "dependencies": {
+      "core": {
+        "discriminator": null
+      }
+    },
+    "experimental_features": {
+      "negative_impls": true,
+      "associated_item_constraints": true,
+      "coupons": true,
+      "user_defined_inline_macros": false
+    }
+  },
+  "linter_configuration": "Off",
+  "plugins": {
+    "builtin_plugins": [
+      "AssertMacros",
+      "Executable",
+      "CairoTest"
+    ]
+  }
+}
+```


### PR DESCRIPTION
We would falsely show `CairoTest` instead of `AssertMacros` if a crate had a dep on `assert_macros`. This happened because inline macros from `AssertMacros` are also in `CairoTest` plugin suite. We should show `AssertMacros` instead since this plugin is more specific. So after this change:
- `assert_macros` dep -> `AssertMacros` in `ViewAnalyzedCrates`
- `cairo_test` dep -> `AssertMacros` and `CairoTest` in `ViewAnalyzedCrates` (this is not false, since technically `CairoTest` + `AssertMacros` == `CairoTest`)