### PR TITLE
Revert "Limit diagnostics threads (#767)"

### DIFF
--- a/src/server/schedule/thread/pool.rs
+++ b/src/server/schedule/thread/pool.rs
@@ -64,8 +64,7 @@ impl Pool {
         /// necessary permissions on a multicore machine than on a single-core one.
         const DEFAULT_PARALLELISM: usize = 4;
 
-        let threads =
-            available_parallelism().map(usize::from).unwrap_or(DEFAULT_PARALLELISM).min(4);
+        let threads = available_parallelism().map(usize::from).unwrap_or(DEFAULT_PARALLELISM);
 
         let (job_sender, job_receiver) = channel::unbounded();
 


### PR DESCRIPTION
This reverts commit e4ea2baf2722d40f61384d0c6489c9f688548fda.
Check maat report for latest nightly - OZ timed out, all times are up by >1000%