### PR TITLE
Reapply "Limit diagnostics threads (#767)" (#776)

### DIFF
--- a/src/server/schedule/thread/pool.rs
+++ b/src/server/schedule/thread/pool.rs
@@ -64,7 +64,8 @@ impl Pool {
         /// necessary permissions on a multicore machine than on a single-core one.
         const DEFAULT_PARALLELISM: usize = 4;
 
-        let threads = available_parallelism().map(usize::from).unwrap_or(DEFAULT_PARALLELISM);
+        let threads =
+            available_parallelism().map(usize::from).unwrap_or(DEFAULT_PARALLELISM).min(4);
 
         let (job_sender, job_receiver) = channel::unbounded();
 


### PR DESCRIPTION
This reverts commit c23c840aa0bded36b10350128aab37cb327ba333.

Turns out cairo-lint slowed stuff down on Maat, not this PR.