### PR TITLE
Filter out empty batches

### DIFF
--- a/src/lang/diagnostics/mod.rs
+++ b/src/lang/diagnostics/mod.rs
@@ -189,8 +189,9 @@ impl DiagnosticsControllerThread {
 
     /// Makes batches out of `files` and spawns workers to run [`refresh_diagnostics`] on them.
     fn spawn_refresh_workers(&mut self, files: &[FileId], state_snapshots: Vec<StateSnapshot>) {
-        let files_batches = batches(files, self.pool.parallelism());
-        assert_eq!(files_batches.len(), state_snapshots.len());
+        let files_batches =
+            batches(files, self.pool.parallelism()).into_iter().filter(|v| !v.is_empty());
+
         for (batch, state) in zip(files_batches, state_snapshots) {
             let scarb_toolchain = self.scarb_toolchain.clone();
             self.spawn_worker(move |project_diagnostics, notifier| {

--- a/src/lang/diagnostics/project_diagnostics.rs
+++ b/src/lang/diagnostics/project_diagnostics.rs
@@ -45,6 +45,7 @@ impl ProjectDiagnostics {
     ///
     /// Returns mapping from a file to its diagnostics for files which diagnostics changed
     /// as a result of the update.
+    #[tracing::instrument(skip_all)]
     pub fn update(
         &self,
         root_on_disk_file_url: Url,


### PR DESCRIPTION
It can happen when there are e.g. less open files than threads in a thread pool.