### PR TITLE
Introduce task without mutable access

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,7 +182,7 @@ impl Config {
             // This conversion is O(1), and makes popping from front also O(1).
             let mut response = VecDeque::from(response);
 
-            Task::local(move |state, _, _, _| {
+            Task::local_mut(move |state, _, _, _| {
                 *state.config = Config::default();
 
                 state.config.unmanaged_core_path = response

--- a/src/server/routing/mod.rs
+++ b/src/server/routing/mod.rs
@@ -150,7 +150,7 @@ fn local_request_task<'a, R: handlers::SyncRequestHandler>(
     request: Request,
 ) -> Result<Task<'a>, LSPError> {
     let (id, params) = cast_request::<R>(request)?;
-    Ok(Task::local(move |state, notifier, requester, responder| {
+    Ok(Task::local_mut(move |state, notifier, requester, responder| {
         let result = R::run(state, notifier, requester, params);
         respond::<R>(id, result, &responder);
     }))
@@ -187,7 +187,7 @@ fn local_notification_task<'a, N: handlers::SyncNotificationHandler>(
     notification: Notification,
 ) -> Result<Task<'a>, LSPError> {
     let (id, params) = cast_notification::<N>(notification)?;
-    Ok(Task::local(move |session, notifier, requester, _| {
+    Ok(Task::local_mut(move |session, notifier, requester, _| {
         if let Err(err) = N::run(session, notifier, requester, params) {
             error!("an error occurred while running {id}: {err}");
         }


### PR DESCRIPTION
This allows us to get access to requester/responder without mut access to state.
This in turn allows us to skip hooks. It is necessary for next PR to not fall into infinite loop.

---

**Stack**:
- #801
- #800 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*