### PR TITLE
Fix invariant for virtual file in `format_output`

### DIFF
--- a/src/ide/macros/expand/format.rs
+++ b/src/ide/macros/expand/format.rs
@@ -13,7 +13,7 @@ pub fn format_output(output: &str, kind: SyntaxKind) -> String {
     let virtual_file = FileLongId::Virtual(VirtualFile {
         parent: Default::default(),
         name: Default::default(),
-        content: Default::default(),
+        content: output.to_owned().into(),
         code_mappings: Default::default(),
         kind: FileKind::Module,
         original_item_removed: false,


### PR DESCRIPTION
## Explanation
Virtual file should contain the exact code which is being parsed and formatted.
Formatting logic broke after `SyntaxNode::get_text` was reworked to use the file content directly by `TextSpan::take`.

## Stack
* https://github.com/software-mansion/cairols/pull/829
* https://github.com/software-mansion/cairols/pull/841 ◀️ 