### PR TITLE
Implement meta LS state 

### DIFF
--- a/src/ide/semantic_highlighting/mod.rs
+++ b/src/ide/semantic_highlighting/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use cairo_lang_filesystem::span::TextOffset;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax as syntax;
@@ -22,7 +20,7 @@ pub mod token_kind;
 pub fn semantic_highlight_full(
     params: SemanticTokensParams,
     db: &AnalysisDatabase,
-    _ls_meta_state: Arc<MetaState>,
+    _ls_meta_state: MetaState,
 ) -> Option<SemanticTokensResult> {
     let file_uri = params.text_document.uri;
     let file = db.file_for_url(&file_uri)?;

--- a/src/ide/semantic_highlighting/mod.rs
+++ b/src/ide/semantic_highlighting/mod.rs
@@ -11,6 +11,7 @@ use self::encoder::{EncodedToken, TokenEncoder};
 pub use self::token_kind::SemanticTokenKind;
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::lsp::LsProtoGroup;
+use crate::state::MetaState;
 
 mod encoder;
 pub mod token_kind;
@@ -19,6 +20,7 @@ pub mod token_kind;
 pub fn semantic_highlight_full(
     params: SemanticTokensParams,
     db: &AnalysisDatabase,
+    _ls_meta_state: MetaState,
 ) -> Option<SemanticTokensResult> {
     let file_uri = params.text_document.uri;
     let file = db.file_for_url(&file_uri)?;

--- a/src/ide/semantic_highlighting/mod.rs
+++ b/src/ide/semantic_highlighting/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use cairo_lang_filesystem::span::TextOffset;
 use cairo_lang_parser::db::ParserGroup;
 use cairo_lang_syntax as syntax;
@@ -20,7 +22,7 @@ pub mod token_kind;
 pub fn semantic_highlight_full(
     params: SemanticTokensParams,
     db: &AnalysisDatabase,
-    _ls_meta_state: MetaState,
+    _ls_meta_state: Arc<MetaState>,
 ) -> Option<SemanticTokensResult> {
     let file_uri = params.text_document.uri;
     let file = db.file_for_url(&file_uri)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,14 +341,14 @@ impl Backend {
                 recv(analysis_progress_status_receiver) -> analysis_progress_status => {
                     let Ok(AnalysisFinished) = analysis_progress_status else { break };
 
-                    scheduler.local(|state, _notifier, requester, _responder|
+                    scheduler.local(|state, _, _notifier, requester, _responder|
                         Self::on_stopped_analysis(state, requester)
                     );
                 }
                 recv(code_lens_request_refresh_receiver) -> error => {
                     let Ok(()) = error else { break };
 
-                    scheduler.local(|_, _, requester, _| {
+                    scheduler.local(|_, _, _, requester, _| {
                         CodeLensController::handle_refresh(requester);
                     });
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,6 @@
 
 use std::path::PathBuf;
 use std::process::ExitCode;
-use std::sync::Arc;
-use std::sync::OnceLock;
 use std::time::SystemTime;
 use std::{io, panic};
 
@@ -407,14 +405,14 @@ impl Backend {
 
     fn register_mutation_in_swapper(
         state: &mut State,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
     ) {
         state.db_swapper.register_mutation();
     }
 
     /// Calls [`lang::db::AnalysisDatabaseSwapper::maybe_swap`] to do its work.
-    fn maybe_swap_database(state: &mut State, _meta_state: Arc<MetaState>, _notifier: Notifier) {
+    fn maybe_swap_database(state: &mut State, _meta_state: MetaState, _notifier: Notifier) {
         state.db_swapper.maybe_swap(
             &mut state.db,
             &state.open_files,
@@ -425,7 +423,7 @@ impl Backend {
     }
 
     /// Calls [`lang::diagnostics::DiagnosticsController::refresh`] to do its work.
-    fn refresh_diagnostics(state: &mut State, _meta_state: Arc<MetaState>, _notifier: Notifier) {
+    fn refresh_diagnostics(state: &mut State, _meta_state: MetaState, _notifier: Notifier) {
         state.diagnostics_controller.refresh(state);
     }
 

--- a/src/server/routing/handlers.rs
+++ b/src/server/routing/handlers.rs
@@ -5,8 +5,6 @@
 // | Commit: 46a457318d8d259376a2b458b3f814b9b795fe69    |
 // +-----------------------------------------------------+
 
-use std::sync::Arc;
-
 use cairo_lang_filesystem::db::{FilesGroup, FilesGroupEx, PrivRawFileContentQuery};
 use lsp_types::notification::{
     DidChangeConfiguration, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
@@ -61,7 +59,7 @@ pub trait SyncRequestHandler: Request {
 pub trait BackgroundDocumentRequestHandler: Request {
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         notifier: Notifier,
         params: <Self as Request>::Params,
     ) -> LSPResult<<Self as Request>::Result>;
@@ -84,7 +82,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequest {
     #[tracing::instrument(name = "textDocument/codeAction", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>, LSPError> {
@@ -125,7 +123,7 @@ impl BackgroundDocumentRequestHandler for HoverRequest {
     #[tracing::instrument(name = "textDocument/hover", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: HoverParams,
     ) -> LSPResult<Option<Hover>> {
@@ -137,7 +135,7 @@ impl BackgroundDocumentRequestHandler for Formatting {
     #[tracing::instrument(name = "textDocument/formatting", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: DocumentFormattingParams,
     ) -> LSPResult<Option<Vec<TextEdit>>> {
@@ -337,7 +335,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinition {
     #[tracing::instrument(name = "textDocument/definition", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: GotoDefinitionParams,
     ) -> LSPResult<Option<GotoDefinitionResponse>> {
@@ -349,7 +347,7 @@ impl BackgroundDocumentRequestHandler for Completion {
     #[tracing::instrument(name = "textDocument/completion", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CompletionParams,
     ) -> LSPResult<Option<CompletionResponse>> {
@@ -361,7 +359,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensFullRequest {
     #[tracing::instrument(name = "textDocument/semanticTokens/full", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        meta_state: Arc<MetaState>,
+        meta_state: MetaState,
         _notifier: Notifier,
         params: SemanticTokensParams,
     ) -> LSPResult<Option<SemanticTokensResult>> {
@@ -373,7 +371,7 @@ impl BackgroundDocumentRequestHandler for ProvideVirtualFile {
     #[tracing::instrument(name = "vfs/provide", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: ProvideVirtualFileRequest,
     ) -> LSPResult<ProvideVirtualFileResponse> {
@@ -391,7 +389,7 @@ impl BackgroundDocumentRequestHandler for ViewAnalyzedCrates {
     #[tracing::instrument(name = "cairo/viewAnalyzedCrates", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<String> {
@@ -403,7 +401,7 @@ impl BackgroundDocumentRequestHandler for ExpandMacro {
     #[tracing::instrument(name = "cairo/expandMacro", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -415,7 +413,7 @@ impl BackgroundDocumentRequestHandler for ToolchainInfo {
     #[tracing::instrument(name = "cairo/toolchainInfo", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<ToolchainInfoResponse> {
@@ -427,7 +425,7 @@ impl BackgroundDocumentRequestHandler for References {
     #[tracing::instrument(name = "textDocument/references", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: ReferenceParams,
     ) -> LSPResult<Option<Vec<lsp_types::Location>>> {
@@ -439,7 +437,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequest {
     #[tracing::instrument(name = "textDocument/documentHighlight", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: DocumentHighlightParams,
     ) -> LSPResult<Option<Vec<DocumentHighlight>>> {
@@ -451,7 +449,7 @@ impl BackgroundDocumentRequestHandler for Rename {
     #[tracing::instrument(name = "textDocument/rename", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: RenameParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -463,7 +461,7 @@ impl BackgroundDocumentRequestHandler for ViewSyntaxTree {
     #[tracing::instrument(name = "cairo/viewSyntaxTree", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -479,7 +477,7 @@ impl BackgroundDocumentRequestHandler for CodeLensRequest {
     #[tracing::instrument(name = "textDocument/codeLens", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CodeLensParams,
     ) -> LSPResult<Option<Vec<CodeLens>>> {
@@ -495,7 +493,7 @@ impl BackgroundDocumentRequestHandler for WillRenameFiles {
     #[tracing::instrument(name = "workspace/willRenameFiles", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: RenameFilesParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -507,7 +505,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequest {
     #[tracing::instrument(name = "textDocument/inlayHint", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: Arc<MetaState>,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: InlayHintParams,
     ) -> LSPResult<Option<Vec<InlayHint>>> {

--- a/src/server/routing/handlers.rs
+++ b/src/server/routing/handlers.rs
@@ -5,6 +5,8 @@
 // | Commit: 46a457318d8d259376a2b458b3f814b9b795fe69    |
 // +-----------------------------------------------------+
 
+use std::sync::Arc;
+
 use cairo_lang_filesystem::db::{FilesGroup, FilesGroupEx, PrivRawFileContentQuery};
 use lsp_types::notification::{
     DidChangeConfiguration, DidChangeTextDocument, DidChangeWatchedFiles, DidCloseTextDocument,
@@ -59,7 +61,7 @@ pub trait SyncRequestHandler: Request {
 pub trait BackgroundDocumentRequestHandler: Request {
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         notifier: Notifier,
         params: <Self as Request>::Params,
     ) -> LSPResult<<Self as Request>::Result>;
@@ -82,7 +84,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequest {
     #[tracing::instrument(name = "textDocument/codeAction", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>, LSPError> {
@@ -123,7 +125,7 @@ impl BackgroundDocumentRequestHandler for HoverRequest {
     #[tracing::instrument(name = "textDocument/hover", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: HoverParams,
     ) -> LSPResult<Option<Hover>> {
@@ -135,7 +137,7 @@ impl BackgroundDocumentRequestHandler for Formatting {
     #[tracing::instrument(name = "textDocument/formatting", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: DocumentFormattingParams,
     ) -> LSPResult<Option<Vec<TextEdit>>> {
@@ -335,7 +337,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinition {
     #[tracing::instrument(name = "textDocument/definition", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: GotoDefinitionParams,
     ) -> LSPResult<Option<GotoDefinitionResponse>> {
@@ -347,7 +349,7 @@ impl BackgroundDocumentRequestHandler for Completion {
     #[tracing::instrument(name = "textDocument/completion", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: CompletionParams,
     ) -> LSPResult<Option<CompletionResponse>> {
@@ -359,7 +361,7 @@ impl BackgroundDocumentRequestHandler for SemanticTokensFullRequest {
     #[tracing::instrument(name = "textDocument/semanticTokens/full", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        meta_state: MetaState,
+        meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: SemanticTokensParams,
     ) -> LSPResult<Option<SemanticTokensResult>> {
@@ -371,7 +373,7 @@ impl BackgroundDocumentRequestHandler for ProvideVirtualFile {
     #[tracing::instrument(name = "vfs/provide", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: ProvideVirtualFileRequest,
     ) -> LSPResult<ProvideVirtualFileResponse> {
@@ -389,7 +391,7 @@ impl BackgroundDocumentRequestHandler for ViewAnalyzedCrates {
     #[tracing::instrument(name = "cairo/viewAnalyzedCrates", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<String> {
@@ -401,7 +403,7 @@ impl BackgroundDocumentRequestHandler for ExpandMacro {
     #[tracing::instrument(name = "cairo/expandMacro", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -413,7 +415,7 @@ impl BackgroundDocumentRequestHandler for ToolchainInfo {
     #[tracing::instrument(name = "cairo/toolchainInfo", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<ToolchainInfoResponse> {
@@ -425,7 +427,7 @@ impl BackgroundDocumentRequestHandler for References {
     #[tracing::instrument(name = "textDocument/references", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: ReferenceParams,
     ) -> LSPResult<Option<Vec<lsp_types::Location>>> {
@@ -437,7 +439,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequest {
     #[tracing::instrument(name = "textDocument/documentHighlight", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: DocumentHighlightParams,
     ) -> LSPResult<Option<Vec<DocumentHighlight>>> {
@@ -449,7 +451,7 @@ impl BackgroundDocumentRequestHandler for Rename {
     #[tracing::instrument(name = "textDocument/rename", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: RenameParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -461,7 +463,7 @@ impl BackgroundDocumentRequestHandler for ViewSyntaxTree {
     #[tracing::instrument(name = "cairo/viewSyntaxTree", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -477,7 +479,7 @@ impl BackgroundDocumentRequestHandler for CodeLensRequest {
     #[tracing::instrument(name = "textDocument/codeLens", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: CodeLensParams,
     ) -> LSPResult<Option<Vec<CodeLens>>> {
@@ -493,7 +495,7 @@ impl BackgroundDocumentRequestHandler for WillRenameFiles {
     #[tracing::instrument(name = "workspace/willRenameFiles", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: RenameFilesParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -505,7 +507,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequest {
     #[tracing::instrument(name = "textDocument/inlayHint", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
-        _meta_state: MetaState,
+        _meta_state: Arc<MetaState>,
         _notifier: Notifier,
         params: InlayHintParams,
     ) -> LSPResult<Option<Vec<InlayHint>>> {

--- a/src/server/routing/handlers.rs
+++ b/src/server/routing/handlers.rs
@@ -38,7 +38,7 @@ use crate::lsp::ext::{
 use crate::lsp::result::{LSPError, LSPResult};
 use crate::server::client::{Notifier, Requester};
 use crate::server::commands::ServerCommands;
-use crate::state::{State, StateSnapshot};
+use crate::state::{MetaState, State, StateSnapshot};
 use crate::toolchain::info::toolchain_info;
 use crate::{Backend, ide, lang};
 
@@ -59,6 +59,7 @@ pub trait SyncRequestHandler: Request {
 pub trait BackgroundDocumentRequestHandler: Request {
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         notifier: Notifier,
         params: <Self as Request>::Params,
     ) -> LSPResult<<Self as Request>::Result>;
@@ -81,6 +82,7 @@ impl BackgroundDocumentRequestHandler for CodeActionRequest {
     #[tracing::instrument(name = "textDocument/codeAction", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CodeActionParams,
     ) -> Result<Option<CodeActionResponse>, LSPError> {
@@ -121,6 +123,7 @@ impl BackgroundDocumentRequestHandler for HoverRequest {
     #[tracing::instrument(name = "textDocument/hover", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: HoverParams,
     ) -> LSPResult<Option<Hover>> {
@@ -132,6 +135,7 @@ impl BackgroundDocumentRequestHandler for Formatting {
     #[tracing::instrument(name = "textDocument/formatting", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: DocumentFormattingParams,
     ) -> LSPResult<Option<Vec<TextEdit>>> {
@@ -331,6 +335,7 @@ impl BackgroundDocumentRequestHandler for GotoDefinition {
     #[tracing::instrument(name = "textDocument/definition", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: GotoDefinitionParams,
     ) -> LSPResult<Option<GotoDefinitionResponse>> {
@@ -342,6 +347,7 @@ impl BackgroundDocumentRequestHandler for Completion {
     #[tracing::instrument(name = "textDocument/completion", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CompletionParams,
     ) -> LSPResult<Option<CompletionResponse>> {
@@ -353,10 +359,11 @@ impl BackgroundDocumentRequestHandler for SemanticTokensFullRequest {
     #[tracing::instrument(name = "textDocument/semanticTokens/full", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        meta_state: MetaState,
         _notifier: Notifier,
         params: SemanticTokensParams,
     ) -> LSPResult<Option<SemanticTokensResult>> {
-        Ok(ide::semantic_highlighting::semantic_highlight_full(params, &snapshot.db))
+        Ok(ide::semantic_highlighting::semantic_highlight_full(params, &snapshot.db, meta_state))
     }
 }
 
@@ -364,6 +371,7 @@ impl BackgroundDocumentRequestHandler for ProvideVirtualFile {
     #[tracing::instrument(name = "vfs/provide", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: ProvideVirtualFileRequest,
     ) -> LSPResult<ProvideVirtualFileResponse> {
@@ -381,6 +389,7 @@ impl BackgroundDocumentRequestHandler for ViewAnalyzedCrates {
     #[tracing::instrument(name = "cairo/viewAnalyzedCrates", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<String> {
@@ -392,6 +401,7 @@ impl BackgroundDocumentRequestHandler for ExpandMacro {
     #[tracing::instrument(name = "cairo/expandMacro", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -403,6 +413,7 @@ impl BackgroundDocumentRequestHandler for ToolchainInfo {
     #[tracing::instrument(name = "cairo/toolchainInfo", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         _params: (),
     ) -> LSPResult<ToolchainInfoResponse> {
@@ -414,6 +425,7 @@ impl BackgroundDocumentRequestHandler for References {
     #[tracing::instrument(name = "textDocument/references", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: ReferenceParams,
     ) -> LSPResult<Option<Vec<lsp_types::Location>>> {
@@ -425,6 +437,7 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequest {
     #[tracing::instrument(name = "textDocument/documentHighlight", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: DocumentHighlightParams,
     ) -> LSPResult<Option<Vec<DocumentHighlight>>> {
@@ -436,6 +449,7 @@ impl BackgroundDocumentRequestHandler for Rename {
     #[tracing::instrument(name = "textDocument/rename", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: RenameParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -447,6 +461,7 @@ impl BackgroundDocumentRequestHandler for ViewSyntaxTree {
     #[tracing::instrument(name = "cairo/viewSyntaxTree", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: TextDocumentPositionParams,
     ) -> LSPResult<Option<String>> {
@@ -462,6 +477,7 @@ impl BackgroundDocumentRequestHandler for CodeLensRequest {
     #[tracing::instrument(name = "textDocument/codeLens", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: CodeLensParams,
     ) -> LSPResult<Option<Vec<CodeLens>>> {
@@ -477,6 +493,7 @@ impl BackgroundDocumentRequestHandler for WillRenameFiles {
     #[tracing::instrument(name = "workspace/willRenameFiles", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: RenameFilesParams,
     ) -> LSPResult<Option<WorkspaceEdit>> {
@@ -488,6 +505,7 @@ impl BackgroundDocumentRequestHandler for InlayHintRequest {
     #[tracing::instrument(name = "textDocument/inlayHint", skip_all)]
     fn run_with_snapshot(
         snapshot: StateSnapshot,
+        _meta_state: MetaState,
         _notifier: Notifier,
         params: InlayHintParams,
     ) -> LSPResult<Option<Vec<InlayHint>>> {

--- a/src/server/routing/mod.rs
+++ b/src/server/routing/mod.rs
@@ -6,7 +6,6 @@
 // +------------------------------------------------------------+
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::Arc;
 
 use anyhow::anyhow;
 pub use handlers::is_cairo_file_path;
@@ -173,8 +172,8 @@ fn background_fmt_task<'a, R: handlers::BackgroundDocumentRequestHandler + 'a>(
 fn create_background_fn_builder<R: handlers::BackgroundDocumentRequestHandler>(
     id: RequestId,
     params: <R as RequestTrait>::Params,
-) -> impl FnOnce(&State, Arc<MetaState>) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static> {
-    move |state: &State, meta_state: Arc<MetaState>| {
+) -> impl FnOnce(&State, MetaState) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static> {
+    move |state: &State, meta_state: MetaState| {
         let state_snapshot = state.snapshot();
         Box::new(move |notifier, responder| {
             let result = catch_unwind(AssertUnwindSafe(|| {

--- a/src/server/routing/mod.rs
+++ b/src/server/routing/mod.rs
@@ -6,6 +6,7 @@
 // +------------------------------------------------------------+
 
 use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Arc;
 
 use anyhow::anyhow;
 pub use handlers::is_cairo_file_path;
@@ -172,8 +173,8 @@ fn background_fmt_task<'a, R: handlers::BackgroundDocumentRequestHandler + 'a>(
 fn create_background_fn_builder<R: handlers::BackgroundDocumentRequestHandler>(
     id: RequestId,
     params: <R as RequestTrait>::Params,
-) -> impl FnOnce(&State, MetaState) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static> {
-    move |state: &State, meta_state: MetaState| {
+) -> impl FnOnce(&State, Arc<MetaState>) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static> {
+    move |state: &State, meta_state: Arc<MetaState>| {
         let state_snapshot = state.snapshot();
         Box::new(move |notifier, responder| {
             let result = catch_unwind(AssertUnwindSafe(|| {

--- a/src/server/schedule/mod.rs
+++ b/src/server/schedule/mod.rs
@@ -5,13 +5,16 @@
 // | Commit: 46a457318d8d259376a2b458b3f814b9b795fe69  |
 // +---------------------------------------------------+
 
+use std::sync::Arc;
+
+use anyhow::Result;
+
 use self::task::BackgroundTaskBuilder;
 use self::thread::{JoinHandle, ThreadPriority};
 use crate::server::client::{Client, Notifier, Requester, Responder};
 use crate::server::connection::ClientSender;
 use crate::server::schedule::task::BackgroundFnBuilder;
 use crate::state::{MetaState, State};
-use anyhow::Result;
 
 mod task;
 pub mod thread;
@@ -48,7 +51,7 @@ pub struct Scheduler<'s> {
     /// fmt request, it will still be processed fast.
     fmt_pool: thread::Pool,
     sync_mut_task_hooks: Vec<SyncTaskHook>,
-    meta_state: MetaState,
+    pub meta_state: Arc<MetaState>,
 }
 
 impl<'s> Scheduler<'s> {
@@ -145,7 +148,7 @@ impl<'s> Scheduler<'s> {
     /// This is a shortcut for `dispatch(Task::local(func))`.
     pub fn local(
         &mut self,
-        func: impl FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's,
+        func: impl FnOnce(&State, Arc<MetaState>, Notifier, &mut Requester<'_>, Responder) + 's,
     ) {
         self.dispatch(Task::local(func));
     }

--- a/src/server/schedule/task.rs
+++ b/src/server/schedule/task.rs
@@ -5,6 +5,8 @@
 // | Commit: 46a457318d8d259376a2b458b3f814b9b795fe69       |
 // +--------------------------------------------------------+
 
+use std::sync::Arc;
+
 use lsp_server::RequestId;
 use serde::Serialize;
 use tracing::error;
@@ -14,12 +16,13 @@ use crate::server::client::{Notifier, Requester, Responder};
 use crate::state::{MetaState, State};
 
 type LocalMutFn<'s> = Box<dyn FnOnce(&mut State, Notifier, &mut Requester<'_>, Responder) + 's>;
-type LocalFn<'s> = Box<dyn FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's>;
+type LocalFn<'s> =
+    Box<dyn FnOnce(&State, Arc<MetaState>, Notifier, &mut Requester<'_>, Responder) + 's>;
 type LocalConditionFn<'s> = Box<dyn FnOnce(&State) -> bool + 's>;
 
 type BackgroundFn = Box<dyn FnOnce(Notifier, Responder) + Send + 'static>;
 
-pub type BackgroundFnBuilder<'s> = Box<dyn FnOnce(&State, MetaState) -> BackgroundFn + 's>;
+pub type BackgroundFnBuilder<'s> = Box<dyn FnOnce(&State, Arc<MetaState>) -> BackgroundFn + 's>;
 
 /// Describes how the task should be run.
 #[derive(Clone, Copy, Debug, Default)]
@@ -77,7 +80,10 @@ pub struct SyncConditionTask<'s> {
 impl<'s> Task<'s> {
     /// Creates a new fmt task.
     pub fn fmt(
-        func: impl FnOnce(&State, MetaState) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static>
+        func: impl FnOnce(
+            &State,
+            Arc<MetaState>,
+        ) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static>
         + 's,
     ) -> Self {
         Self::Fmt(Box::new(func))
@@ -86,7 +92,10 @@ impl<'s> Task<'s> {
     /// Creates a new background task.
     pub fn background(
         schedule: BackgroundSchedule,
-        func: impl FnOnce(&State, MetaState) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static>
+        func: impl FnOnce(
+            &State,
+            Arc<MetaState>,
+        ) -> Box<dyn FnOnce(Notifier, Responder) + Send + 'static>
         + 's,
     ) -> Self {
         Self::Background(BackgroundTaskBuilder { schedule, builder: Box::new(func) })
@@ -101,7 +110,7 @@ impl<'s> Task<'s> {
 
     /// Creates a new local task without access to the mutable state.
     pub fn local(
-        func: impl FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's,
+        func: impl FnOnce(&State, Arc<MetaState>, Notifier, &mut Requester<'_>, Responder) + 's,
     ) -> Self {
         Self::Sync(SyncTask { func: Box::new(func) })
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::default::Default;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use lsp_types::{ClientCapabilities, Url};
 use salsa::ParallelDatabase;
@@ -86,10 +86,12 @@ impl State {
     }
 }
 
+#[derive(Default)]
+pub struct MetaStateInner {}
+
 /// State keeps information about LS state (swapper, analysis state or other internal info)
-/// Mutations don't influence refreshing of diagnostics and hooks etc.
-#[derive(Default, Clone)]
-pub struct MetaState {}
+/// Mutations of this struct are allowed in background tasks and do not trigger hooks.
+pub type MetaState = Arc<Mutex<MetaStateInner>>;
 
 /// Readonly snapshot of Language server state.
 pub struct StateSnapshot {

--- a/src/state.rs
+++ b/src/state.rs
@@ -86,6 +86,11 @@ impl State {
     }
 }
 
+/// State keeps information about LS state (swapper, analysis state or other internal info)
+/// Mutations don't influence refreshing of diagnostics and hooks etc.
+#[derive(Default, Clone)]
+pub struct MetaState {}
+
 /// Readonly snapshot of Language server state.
 pub struct StateSnapshot {
     pub db: salsa::Snapshot<AnalysisDatabase>,


### PR DESCRIPTION
It's needed for #823 and #799 in order to keep information about swapper state and analysis progress without launching the hooks