### PR TITLE
Add retries to `semanticTokens` in tests

### DIFF
--- a/tests/e2e/semantic_tokens/mod.rs
+++ b/tests/e2e/semantic_tokens/mod.rs
@@ -19,6 +19,8 @@ fn semantic_tokens(code: &str) -> String {
 
     ls.open_all_and_wait_for_diagnostics_generation();
 
+    // TODO(#875): Once condvar logic is in place, this retry logic will become obsolete
+    // region: Retries logic
     let mut retries = 0;
     let res = loop {
         let response = ls.send_request::<lsp_request!("textDocument/semanticTokens/full")>(
@@ -38,6 +40,7 @@ fn semantic_tokens(code: &str) -> String {
         thread::sleep(time::Duration::from_millis(1000));
         retries += 1;
     };
+    // endregion
 
     let lsp_types::SemanticTokensResult::Tokens(tokens) = res else {
         panic!("expected full tokens")

--- a/tests/e2e/semantic_tokens/mod.rs
+++ b/tests/e2e/semantic_tokens/mod.rs
@@ -1,5 +1,6 @@
 use cairo_language_server::testing::SemanticTokenKind;
 use lsp_types::{Position, Range, lsp_request};
+use std::{thread, time};
 
 use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2023_11;
 use crate::support::cursor::render_text_with_annotations;
@@ -34,6 +35,7 @@ fn semantic_tokens(code: &str) -> String {
             panic!("Max test textDocument/semanticTokens retries exceeded");
         }
 
+        thread::sleep(time::Duration::from_millis(1000));
         retries += 1;
     };
 


### PR DESCRIPTION
This should be made obsolete with #875 