### PR TITLE
Remove conditional task in favour of revision check

### DIFF
--- a/src/server/schedule/mod.rs
+++ b/src/server/schedule/mod.rs
@@ -8,6 +8,7 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
+use salsa::plumbing::current_revision;
 
 use self::task::BackgroundTaskBuilder;
 use self::thread::{JoinHandle, ThreadPriority};
@@ -21,7 +22,7 @@ pub mod thread;
 
 pub(super) use self::task::BackgroundSchedule;
 pub use self::task::{SyncMutTask, Task};
-use crate::server::schedule::task::{SyncConditionTask, SyncTask};
+use crate::server::schedule::task::SyncTask;
 
 /// The event loop thread is actually a secondary thread that we spawn from the
 /// _actual_ main thread. This secondary thread has a larger stack size
@@ -91,10 +92,14 @@ impl<'s> Scheduler<'s> {
             Task::SyncMut(SyncMutTask { func }) => {
                 let notifier = self.client.notifier();
                 let responder = self.client.responder();
+                let old_revision = current_revision(&self.state.db);
                 func(self.state, notifier.clone(), &mut self.client.requester, responder);
+                let new_revision = current_revision(&self.state.db);
 
-                for hook in &self.sync_mut_task_hooks {
-                    hook(self.state, self.meta_state.clone(), notifier.clone());
+                if old_revision != new_revision {
+                    for hook in &self.sync_mut_task_hooks {
+                        hook(self.state, self.meta_state.clone(), notifier.clone());
+                    }
                 }
             }
             Task::Sync(SyncTask { func }) => {
@@ -107,17 +112,6 @@ impl<'s> Scheduler<'s> {
                     &mut self.client.requester,
                     responder,
                 );
-            }
-            Task::SyncConditional(SyncConditionTask { precondition_func, mut_func }) => {
-                if precondition_func(self.state) {
-                    let notifier = self.client.notifier();
-                    let responder = self.client.responder();
-                    mut_func(self.state, notifier.clone(), &mut self.client.requester, responder);
-
-                    for hook in &self.sync_mut_task_hooks {
-                        hook(self.state, self.meta_state.clone(), notifier.clone());
-                    }
-                };
             }
             Task::Background(BackgroundTaskBuilder { schedule, builder: func }) => {
                 let task = build_task_fn(func);
@@ -156,17 +150,6 @@ impl<'s> Scheduler<'s> {
         func: impl FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's,
     ) {
         self.dispatch(Task::local(func));
-    }
-
-    /// Dispatches a local conditional `task`.
-    ///
-    /// This is a shortcut for `dispatch(Task::local_with_precondition(precondition_func, mut_func))`.
-    pub fn local_with_precondition(
-        &mut self,
-        precondition_func: impl FnOnce(&State) -> bool + 's,
-        mut_func: impl FnOnce(&mut State, Notifier, &mut Requester<'_>, Responder) + 's,
-    ) {
-        self.dispatch(Task::local_with_precondition(precondition_func, mut_func));
     }
 
     /// Registers a hook to be called each time a synchronous task with access to mutable state is executed.

--- a/src/server/schedule/task.rs
+++ b/src/server/schedule/task.rs
@@ -15,7 +15,6 @@ use crate::state::{MetaState, State};
 
 type LocalMutFn<'s> = Box<dyn FnOnce(&mut State, Notifier, &mut Requester<'_>, Responder) + 's>;
 type LocalFn<'s> = Box<dyn FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's>;
-type LocalConditionFn<'s> = Box<dyn FnOnce(&State) -> bool + 's>;
 
 type BackgroundFn = Box<dyn FnOnce(Notifier, Responder) + Send + 'static>;
 
@@ -45,7 +44,6 @@ pub enum Task<'s> {
     Background(BackgroundTaskBuilder<'s>),
     Sync(SyncTask<'s>),
     SyncMut(SyncMutTask<'s>),
-    SyncConditional(SyncConditionTask<'s>),
 }
 
 // The reason why this isn't just a 'static background closure
@@ -68,10 +66,6 @@ pub struct SyncMutTask<'s> {
 
 pub struct SyncTask<'s> {
     pub func: LocalFn<'s>,
-}
-pub struct SyncConditionTask<'s> {
-    pub precondition_func: LocalConditionFn<'s>,
-    pub mut_func: LocalMutFn<'s>,
 }
 
 impl<'s> Task<'s> {
@@ -104,19 +98,6 @@ impl<'s> Task<'s> {
         func: impl FnOnce(&State, MetaState, Notifier, &mut Requester<'_>, Responder) + 's,
     ) -> Self {
         Self::Sync(SyncTask { func: Box::new(func) })
-    }
-
-    /// Creates a new local task with access to the mutable state that runs only if a condition is satisfied.
-    ///
-    /// This pattern is useful when checking the precondition to running the task requires access to [`State`].
-    pub fn local_with_precondition(
-        precondition_func: impl FnOnce(&State) -> bool + 's,
-        mut_func: impl FnOnce(&mut State, Notifier, &mut Requester<'_>, Responder) + 's,
-    ) -> Self {
-        Self::SyncConditional(SyncConditionTask {
-            precondition_func: Box::new(precondition_func),
-            mut_func: Box::new(mut_func),
-        })
     }
 
     /// Creates a local task that immediately responds with the provided `request`.


### PR DESCRIPTION
Now salsa exposes api to obtain current revision. This is cleaner and even slightly faster.