### PR TITLE
Use nightly Rust toolchain for the format check

### DIFF
--- a/.github/workflows/cairo-update-check.yml
+++ b/.github/workflows/cairo-update-check.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
   schedule:
-    - cron: '0 0 * * 1-5'
+    - cron: "0 0 * * 1-5"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [ 1, 2, 3, 4 ]
+        partition: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [ 1, 2, 3, 4 ]
+        partition: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -58,7 +58,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check
       - run: cargo lint

--- a/.github/workflows/scarb-nightly-check.yml
+++ b/.github/workflows/scarb-nightly-check.yml
@@ -1,7 +1,7 @@
 name: Check new scarb nightly
 on:
   repository_dispatch:
-    types: [ new-scarb-nightly-published ]
+    types: [new-scarb-nightly-published]
   workflow_dispatch:
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [ 1, 2, 3, 4 ]
+        partition: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable

--- a/src/ide/code_actions/mod.rs
+++ b/src/ide/code_actions/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ops::Not;
 
 use cairo_lang_syntax::node::SyntaxNode;
 use itertools::Itertools;
@@ -12,7 +13,6 @@ use crate::lang::analysis_context::AnalysisContext;
 use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
 use crate::lang::lsp::{LsProtoGroup, ToCairo};
 use crate::project::ConfigsRegistry;
-use std::ops::Not;
 
 mod add_missing_trait;
 mod cairo_lint;

--- a/src/ide/code_actions/suggest_similar_member.rs
+++ b/src/ide/code_actions/suggest_similar_member.rs
@@ -1,15 +1,17 @@
-use crate::lang::analysis_context::AnalysisContext;
-use crate::lang::db::AnalysisDatabase;
-use crate::lang::lsp::ToLsp;
-use crate::lang::members::find_members_for_type;
-use crate::lang::text_matching::text_matches;
+use std::collections::HashMap;
+
 use cairo_lang_semantic::items::function_with_body::{
     FunctionWithBodySemantic, SemanticExprLookup,
 };
 use cairo_lang_semantic::lookup_item::LookupItemEx;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
 use lsp_types::{CodeAction, CodeActionKind, TextEdit, Url, WorkspaceEdit};
-use std::collections::HashMap;
+
+use crate::lang::analysis_context::AnalysisContext;
+use crate::lang::db::AnalysisDatabase;
+use crate::lang::lsp::ToLsp;
+use crate::lang::members::find_members_for_type;
+use crate::lang::text_matching::text_matches;
 
 pub fn suggest_similar_member<'db>(
     db: &'db AnalysisDatabase,

--- a/src/ide/code_actions/suggest_similar_method.rs
+++ b/src/ide/code_actions/suggest_similar_method.rs
@@ -1,9 +1,5 @@
-use crate::lang::analysis_context::AnalysisContext;
-use crate::lang::db::AnalysisDatabase;
-use crate::lang::importer::import_edit_for_trait_if_needed;
-use crate::lang::lsp::ToLsp;
-use crate::lang::methods::find_methods_for_type;
-use crate::lang::text_matching::text_matches;
+use std::collections::HashMap;
+
 use cairo_lang_defs::ids::NamedLanguageElementLongId;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::items::function_with_body::{
@@ -13,7 +9,13 @@ use cairo_lang_semantic::lookup_item::LookupItemEx;
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_lang_utils::Upcast;
 use lsp_types::{CodeAction, CodeActionKind, TextEdit, Url, WorkspaceEdit};
-use std::collections::HashMap;
+
+use crate::lang::analysis_context::AnalysisContext;
+use crate::lang::db::AnalysisDatabase;
+use crate::lang::importer::import_edit_for_trait_if_needed;
+use crate::lang::lsp::ToLsp;
+use crate::lang::methods::find_methods_for_type;
+use crate::lang::text_matching::text_matches;
 
 /// Create a Quick Fix code action to substitute this call with a similar one.
 pub fn suggest_similar_method<'db>(

--- a/src/ide/code_lens/executables.rs
+++ b/src/ide/code_lens/executables.rs
@@ -1,3 +1,11 @@
+use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_defs::ids::ModuleId;
+use cairo_lang_executable_plugin::EXECUTABLE_ATTR;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+use cairo_lang_syntax::node::helpers::QueryAttrs;
+use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
+use lsp_types::{CodeLens, Command, Position, Range, Url};
+
 use crate::ide::code_lens::{
     AnnotatedNode, CodeLensBuilder, CodeLensInterface, CodeLensProvider, LSCodeLens,
     collect_functions_with_attrs, get_original_module_item_and_file, make_lens_args,
@@ -8,13 +16,6 @@ use crate::lang::lsp::{LsProtoGroup, ToLsp};
 use crate::project::builtin_plugins::BuiltinPlugin;
 use crate::server::client::Notifier;
 use crate::state::State;
-use cairo_lang_defs::db::DefsGroup;
-use cairo_lang_defs::ids::ModuleId;
-use cairo_lang_executable_plugin::EXECUTABLE_ATTR;
-use cairo_lang_syntax::node::TypedSyntaxNode;
-use cairo_lang_syntax::node::helpers::QueryAttrs;
-use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use lsp_types::{CodeLens, Command, Position, Range, Url};
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct ExecutableCodeLens {

--- a/src/ide/code_lens/mod.rs
+++ b/src/ide/code_lens/mod.rs
@@ -1,17 +1,10 @@
-use crate::config::Config;
-use crate::ide::code_lens::executables::{
-    ExecutableCodeLens, ExecutableCodeLensConstructionParams, ExecutableCodeLensProvider,
-};
-use crate::ide::code_lens::tests::{
-    TestCodeLens, TestCodeLensConstructionParams, TestCodeLensProvider,
-};
-use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
-use crate::lsp::capabilities::client::ClientCapabilitiesExt;
-use crate::lsp::ext::{ExecuteInTerminal, ExecuteInTerminalParams};
-use crate::server::client::{Notifier, Requester};
-use crate::server::schedule::thread::{JoinHandle, ThreadPriority};
-use crate::server::schedule::{Task, thread};
-use crate::state::State;
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+use std::vec;
+
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{ModuleId, ModuleItemId, TopLevelLanguageElementId};
 use cairo_lang_filesystem::db::get_originating_location;
@@ -26,12 +19,21 @@ use lsp_types::notification::ShowMessage;
 use lsp_types::request::CodeLensRefresh;
 use lsp_types::{CodeLens, MessageType, ShowMessageParams, Url};
 use serde_json::{Number, Value};
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
-use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
-use std::vec;
+
+use crate::config::Config;
+use crate::ide::code_lens::executables::{
+    ExecutableCodeLens, ExecutableCodeLensConstructionParams, ExecutableCodeLensProvider,
+};
+use crate::ide::code_lens::tests::{
+    TestCodeLens, TestCodeLensConstructionParams, TestCodeLensProvider,
+};
+use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
+use crate::lsp::capabilities::client::ClientCapabilitiesExt;
+use crate::lsp::ext::{ExecuteInTerminal, ExecuteInTerminalParams};
+use crate::server::client::{Notifier, Requester};
+use crate::server::schedule::thread::{JoinHandle, ThreadPriority};
+use crate::server::schedule::{Task, thread};
+use crate::state::State;
 
 mod executables;
 mod tests;

--- a/src/ide/code_lens/tests.rs
+++ b/src/ide/code_lens/tests.rs
@@ -1,16 +1,5 @@
-use super::{
-    AnnotatedNode, CodeLensBuilder, CodeLensInterface, CodeLensProvider, LSCodeLens,
-    collect_functions_with_attrs, get_original_module_item_and_file, make_lens_args,
-    send_execute_in_terminal,
-};
-use crate::config::{Config, TestRunner};
-use crate::lang::db::AnalysisDatabase;
-use crate::lang::db::LsSemanticGroup;
-use crate::lang::db::LsSyntaxGroup;
-use crate::lang::lsp::ToLsp;
-use crate::lang::lsp::{LsProtoGroup, ToCairo};
-use crate::server::client::Notifier;
-use crate::state::State;
+use std::ops::Not;
+
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::FreeFunctionLongId;
 use cairo_lang_defs::ids::ModuleFileId;
@@ -28,7 +17,19 @@ use cairo_lang_test_plugin::TestPlugin;
 use cairo_lang_utils::Intern;
 use lsp_types::{CodeLens, Command, Position, Range, Url};
 
-use std::ops::Not;
+use super::{
+    AnnotatedNode, CodeLensBuilder, CodeLensInterface, CodeLensProvider, LSCodeLens,
+    collect_functions_with_attrs, get_original_module_item_and_file, make_lens_args,
+    send_execute_in_terminal,
+};
+use crate::config::{Config, TestRunner};
+use crate::lang::db::AnalysisDatabase;
+use crate::lang::db::LsSemanticGroup;
+use crate::lang::db::LsSyntaxGroup;
+use crate::lang::lsp::ToLsp;
+use crate::lang::lsp::{LsProtoGroup, ToCairo};
+use crate::server::client::Notifier;
+use crate::state::State;
 
 #[derive(PartialEq, Clone, Debug)]
 pub struct TestCodeLens {

--- a/src/ide/completion/dot_completions.rs
+++ b/src/ide/completion/dot_completions.rs
@@ -1,9 +1,14 @@
 use cairo_lang_defs::ids::{NamedLanguageElementId, TopLevelLanguageElementId, TraitFunctionId};
+use cairo_lang_filesystem::ids::CrateId;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_semantic::items::function_with_body::{
     FunctionWithBodySemantic, SemanticExprLookup,
 };
+use cairo_lang_semantic::items::imp::ImplSemantic;
+use cairo_lang_semantic::items::structure::StructSemantic;
+use cairo_lang_semantic::items::trt::TraitSemantic;
 use cairo_lang_semantic::lookup_item::LookupItemEx;
+use cairo_lang_semantic::lsp_helpers::LspHelpers;
 use cairo_lang_semantic::types::peel_snapshots;
 use cairo_lang_semantic::{ConcreteTypeId, TypeId, TypeLongId};
 use cairo_lang_syntax::node::{TypedStablePtr, TypedSyntaxNode};
@@ -21,11 +26,6 @@ use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
 use crate::lang::importer::import_edit_for_trait_if_needed;
 use crate::lang::methods::find_methods_for_type;
 use crate::lang::text_matching::text_matches;
-use cairo_lang_filesystem::ids::CrateId;
-use cairo_lang_semantic::items::imp::ImplSemantic;
-use cairo_lang_semantic::items::structure::StructSemantic;
-use cairo_lang_semantic::items::trt::TraitSemantic;
-use cairo_lang_semantic::lsp_helpers::LspHelpers;
 
 pub fn dot_completions<'db>(
     db: &'db AnalysisDatabase,

--- a/src/ide/completion/function/variables.rs
+++ b/src/ide/completion/function/variables.rs
@@ -8,6 +8,7 @@ use cairo_lang_syntax::node::ast::{PathSegment, StatementLet};
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{Token, TypedSyntaxNode};
 use itertools::Itertools;
+use lsp_types::{CompletionItem, CompletionItemKind};
 
 use crate::ide::completion::expr::selector::expr_selector;
 use crate::ide::completion::helpers::binary_expr::dot_rhs::dot_expr_rhs;
@@ -15,7 +16,6 @@ use crate::ide::completion::{CompletionItemOrderable, CompletionRelevance};
 use crate::lang::analysis_context::AnalysisContext;
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::text_matching::text_matches;
-use lsp_types::{CompletionItem, CompletionItemKind};
 
 pub fn variables_completions<'db>(
     db: &'db AnalysisDatabase,

--- a/src/ide/completion/helpers/item.rs
+++ b/src/ide/completion/helpers/item.rs
@@ -1,8 +1,8 @@
 use std::cmp::Ordering;
+use std::hash::Hash;
 
 use lsp_types::CompletionItem;
 use serde::Serialize;
-use std::hash::Hash;
 
 // Specifies how relevant a completion is relative to the scope of the current cursor position.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Debug, Copy)]

--- a/src/ide/semantic_highlighting/mod.rs
+++ b/src/ide/semantic_highlighting/mod.rs
@@ -1,3 +1,6 @@
+use lsp_types::{SemanticTokens, SemanticTokensParams, SemanticTokensResult};
+use tracing::error;
+
 pub use self::token_kind::SemanticTokenKind;
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::lsp::LsProtoGroup;
@@ -6,8 +9,6 @@ use crate::{
     ide::semantic_highlighting::token_traverser::SemanticTokensTraverser,
     lang::db::upstream::file_syntax,
 };
-use lsp_types::{SemanticTokens, SemanticTokensParams, SemanticTokensResult};
-use tracing::error;
 
 mod encoder;
 pub mod token_kind;

--- a/src/lang/db/semantic.rs
+++ b/src/lang/db/semantic.rs
@@ -33,12 +33,11 @@ use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
-
-use crate::lang::db::SyntaxNodeExt;
-use crate::lang::db::upstream::file_syntax;
+use salsa::Database;
 
 use super::LsSyntaxGroup;
-use salsa::Database;
+use crate::lang::db::SyntaxNodeExt;
+use crate::lang::db::upstream::file_syntax;
 
 pub trait LsSemanticGroup: Database {
     /// Returns a [`LookupItemId`] corresponding to the node or its first parent all the way up to

--- a/src/lang/db/swapper.rs
+++ b/src/lang/db/swapper.rs
@@ -10,6 +10,7 @@ use cairo_lang_semantic::db::{SemanticGroup, semantic_group_input};
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use crossbeam::channel::Sender;
 use lsp_types::Url;
+use salsa::Setter;
 use serde::Serialize;
 use tracing::{error, trace, warn};
 
@@ -20,7 +21,6 @@ use crate::lang::lsp::LsProtoGroup;
 use crate::lang::proc_macros::controller::ProcMacroClientController;
 use crate::lang::proc_macros::db::ProcMacroGroup;
 use crate::project::ProjectController;
-use salsa::Setter;
 
 #[derive(Debug, Clone, Copy, Serialize)]
 pub enum SwapReason {

--- a/src/lang/db/syntax.rs
+++ b/src/lang/db/syntax.rs
@@ -1,10 +1,11 @@
-use crate::lang::db::upstream::file_syntax;
 use cairo_lang_diagnostics::ToOption;
 use cairo_lang_filesystem::ids::FileId;
 use cairo_lang_filesystem::span::{TextOffset, TextPosition, TextSpan};
 use cairo_lang_syntax::node::ast::TerminalIdentifier;
 use cairo_lang_syntax::node::{SyntaxNode, Terminal};
 use salsa::Database;
+
+use crate::lang::db::upstream::file_syntax;
 
 /// LS-specific extensions to the syntax group of the Cairo compiler.
 pub trait LsSyntaxGroup: Database {

--- a/src/lang/defs/mod.rs
+++ b/src/lang/defs/mod.rs
@@ -1,14 +1,3 @@
-pub use self::finder::ResolvedItem;
-pub use self::finder::{find_declaration, find_definition};
-pub use self::generic_param::GenericParamDef;
-pub use self::item::ItemDef;
-pub use self::member::MemberDef;
-pub use self::module::ModuleDef;
-pub use self::variable::VariableDef;
-pub use self::variant::VariantDef;
-use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
-use crate::lang::usages::FindUsages;
-use crate::lang::usages::search_scope::SearchScope;
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{LanguageElementId, MacroCallId, ModuleId};
 use cairo_lang_filesystem::db::get_originating_location;
@@ -23,6 +12,18 @@ use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
 use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{TypedSyntaxNode, ast};
+
+pub use self::finder::ResolvedItem;
+pub use self::finder::{find_declaration, find_definition};
+pub use self::generic_param::GenericParamDef;
+pub use self::item::ItemDef;
+pub use self::member::MemberDef;
+pub use self::module::ModuleDef;
+pub use self::variable::VariableDef;
+pub use self::variant::VariantDef;
+use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::usages::FindUsages;
+use crate::lang::usages::search_scope::SearchScope;
 
 mod finder;
 mod generic_param;

--- a/src/lang/diagnostics/file_diagnostics.rs
+++ b/src/lang/diagnostics/file_diagnostics.rs
@@ -14,6 +14,7 @@ use cairo_lang_semantic::diagnostic::SemanticDiagnosticKind;
 use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use cairo_lint::{CairoLintToolMetadata, LinterDiagnosticParams, LinterGroup};
 use lsp_types::{Diagnostic, Url};
+use salsa::Database;
 use tracing::info_span;
 
 use crate::config::Config;
@@ -22,7 +23,6 @@ use crate::lang::diagnostics::lsp::map_cairo_diagnostics_to_lsp;
 use crate::lang::lsp::LsProtoGroup;
 use crate::project::ConfigsRegistry;
 use crate::toolchain::scarb::ScarbToolchain;
-use salsa::Database;
 
 /// Result of processing a single on disk file `root_on_disk_file` and virtual files that are its
 /// descendants in search for diagnostics.

--- a/src/lang/diagnostics/lsp.rs
+++ b/src/lang/diagnostics/lsp.rs
@@ -9,10 +9,10 @@ use lsp_types::{
     Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString, Range,
     Url,
 };
+use salsa::{AsDynDatabase, Database};
 use tracing::{error, trace};
 
 use crate::lang::lsp::{LsProtoGroup, ToLsp};
-use salsa::{AsDynDatabase, Database};
 
 /// Converts internal diagnostics to LSP format.
 pub fn map_cairo_diagnostics_to_lsp<'db, T>(

--- a/src/lang/importer.rs
+++ b/src/lang/importer.rs
@@ -4,6 +4,7 @@ use cairo_lang_defs::{
     db::DefsGroup,
     ids::{LanguageElementId, ModuleId},
 };
+use cairo_lang_semantic::lsp_helpers::LspHelpers;
 use cairo_lang_syntax::node::{
     TypedStablePtr, TypedSyntaxNode, ast::ItemUse, ids::SyntaxStablePtrId,
 };
@@ -11,7 +12,6 @@ use lsp_types::{Position, Range, TextEdit};
 
 use super::{analysis_context::AnalysisContext, db::AnalysisDatabase};
 use crate::lang::{db::LsSemanticGroup, lsp::ToLsp};
-use cairo_lang_semantic::lsp_helpers::LspHelpers;
 
 /// Returns a TextEdit to import the given trait if it is not already in scope.
 /// The decision is based on visibility from the current module in `ctx`.

--- a/src/lang/lsp/ls_proto_group.rs
+++ b/src/lang/lsp/ls_proto_group.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroU32;
 
+use cairo_lang_filesystem::db::ext_as_virtual;
 use cairo_lang_filesystem::ids::{FileId, FileLongId};
 use cairo_lang_filesystem::span::TextSpan;
 use cairo_lang_utils::Intern;
@@ -8,7 +9,6 @@ use salsa::{Database, Id};
 use tracing::error;
 
 use crate::lang::lsp::ToLsp;
-use cairo_lang_filesystem::db::ext_as_virtual;
 
 #[cfg(test)]
 #[path = "ls_proto_group_test.rs"]

--- a/src/lang/lsp/ls_proto_group_test.rs
+++ b/src/lang/lsp/ls_proto_group_test.rs
@@ -1,9 +1,9 @@
 use cairo_lang_filesystem::ids::{FileKind, FileLongId, VirtualFile};
 use cairo_lang_utils::Intern;
 use lsp_types::Url;
+use salsa::AsDynDatabase;
 
 use crate::lang::{db::AnalysisDatabase, lsp::LsProtoGroup};
-use salsa::AsDynDatabase;
 
 #[test]
 fn file_url() {

--- a/src/lang/members.rs
+++ b/src/lang/members.rs
@@ -1,9 +1,10 @@
-use crate::lang::db::AnalysisDatabase;
 use cairo_lang_defs::ids::FunctionWithBodyId;
 use cairo_lang_filesystem::ids::StrRef;
 use cairo_lang_semantic::items::free_function::FreeFunctionSemantic;
 use cairo_lang_semantic::items::imp::ImplSemantic;
 use cairo_lang_semantic::items::trt::TraitSemantic;
+
+use crate::lang::db::AnalysisDatabase;
 
 /// Finds and returns the members associated with a given type in the context of the specified function.
 pub fn find_members_for_type<'db>(

--- a/src/lang/proc_macros/cache.rs
+++ b/src/lang/proc_macros/cache.rs
@@ -4,6 +4,8 @@ use bincode::{
     config::standard,
     serde::{decode_from_slice, encode_to_vec},
 };
+use salsa::{Database, Setter};
+use scarb_proc_macro_server_types::methods::ProcMacroResult;
 use serde::{Deserialize, Serialize};
 use tracing::error;
 
@@ -15,8 +17,6 @@ use crate::{
         PlainExpandAttributeParams, PlainExpandDeriveParams, PlainExpandInlineParams,
     },
 };
-use salsa::{Database, Setter};
-use scarb_proc_macro_server_types::methods::ProcMacroResult;
 
 pub fn save_proc_macro_cache(db: &dyn Database, config: &Config) {
     if !config.enable_experimental_proc_macro_cache {

--- a/src/lang/proc_macros/controller.rs
+++ b/src/lang/proc_macros/controller.rs
@@ -16,7 +16,9 @@ use governor::{Quota, RateLimiter};
 use lsp_types::notification::ShowMessage;
 use lsp_types::request::SemanticTokensRefresh;
 use lsp_types::{ClientCapabilities, MessageType, ShowMessageParams};
+use salsa::Setter;
 use scarb_proc_macro_server_types::jsonrpc::RpcResponse;
+use scarb_proc_macro_server_types::methods::ProcMacroResult;
 use tracing::error;
 
 use super::client::connection::ProcMacroServerConnection;
@@ -34,8 +36,6 @@ use crate::server::client::{Notifier, Requester};
 use crate::server::schedule::Task;
 use crate::server::schedule::thread::JoinHandle;
 use crate::toolchain::scarb::ScarbToolchain;
-use salsa::Setter;
-use scarb_proc_macro_server_types::methods::ProcMacroResult;
 
 const RESTART_RATE_LIMITER_PERIOD_SEC: u64 = 180;
 const RESTART_RATE_LIMITER_RETRIES: u32 = 5;

--- a/src/lang/proc_macros/db.rs
+++ b/src/lang/proc_macros/db.rs
@@ -1,10 +1,5 @@
 use std::collections::HashMap;
 
-use super::client::{RequestParams, ServerStatus};
-use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
-use crate::lang::proc_macros::client::plain_request_response::{
-    PlainExpandAttributeParams, PlainExpandDeriveParams, PlainExpandInlineParams,
-};
 use cairo_lang_filesystem::db::get_originating_location;
 use cairo_lang_macro::{Diagnostic, TextSpan, TokenStream, TokenTree};
 use cairo_lang_syntax::node::SyntaxNode;
@@ -13,6 +8,12 @@ use scarb_proc_macro_server_types::conversions::token_stream_v2_to_v1;
 use scarb_proc_macro_server_types::methods::{
     CodeOrigin, ProcMacroResult,
     expand::{ExpandAttributeParams, ExpandDeriveParams, ExpandInlineMacroParams},
+};
+
+use super::client::{RequestParams, ServerStatus};
+use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
+use crate::lang::proc_macros::client::plain_request_response::{
+    PlainExpandAttributeParams, PlainExpandDeriveParams, PlainExpandInlineParams,
 };
 
 /// A set of queries that enable access to proc macro client from compiler plugins

--- a/src/lang/proc_macros/plugins/downcast.rs
+++ b/src/lang/proc_macros/plugins/downcast.rs
@@ -1,5 +1,6 @@
-use crate::lang::db::AnalysisDatabase;
 use salsa::Database;
+
+use crate::lang::db::AnalysisDatabase;
 
 /// This function is necessary due to trait bounds that cannot be bypassed in any other way.
 /// `generate_code()` takes db: [`&dyn Database`](`Database`),
@@ -26,6 +27,7 @@ mod unsafe_downcast_ref_tests {
     use std::collections::HashMap;
 
     use cairo_lang_macro_v1::TokenStream;
+    use salsa::{Database, Setter};
     use scarb_proc_macro_server_types::methods::ProcMacroResult;
     use scarb_proc_macro_server_types::scope::ProcMacroScope;
 
@@ -33,7 +35,6 @@ mod unsafe_downcast_ref_tests {
     use crate::lang::db::AnalysisDatabase;
     use crate::lang::proc_macros::client::plain_request_response::PlainExpandAttributeParams;
     use crate::lang::proc_macros::db::ProcMacroGroup;
-    use salsa::{Database, Setter};
 
     #[test]
     fn cast_succeed() {

--- a/src/lang/proc_macros/plugins/mod.rs
+++ b/src/lang/proc_macros/plugins/mod.rs
@@ -10,6 +10,7 @@ use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
 use convert_case::{Case, Casing};
 use downcast::unsafe_downcast_ref;
 use itertools::Itertools;
+use salsa::Database;
 use scarb::inline::inline_macro_generate_code;
 use scarb::regular::macro_generate_code;
 use scarb_proc_macro_server_types::methods::defined_macros::{
@@ -18,7 +19,6 @@ use scarb_proc_macro_server_types::methods::defined_macros::{
 use scarb_proc_macro_server_types::scope::{CompilationUnitComponent, ProcMacroScope};
 
 use crate::lang::plugins::DowncastRefUnchecked;
-use salsa::Database;
 
 mod downcast;
 // TODO(#6666) Evict this module when this is possible.

--- a/src/project/crate_data.rs
+++ b/src/project/crate_data.rs
@@ -1,6 +1,7 @@
-use super::builtin_plugins::BuiltinPlugin;
-use crate::lang::db::AnalysisDatabase;
-use crate::project::model::PackageConfig;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::ModuleId;
 use cairo_lang_filesystem::db::{
@@ -14,9 +15,10 @@ use cairo_lang_semantic::plugin::PluginSuite;
 use cairo_lang_utils::Intern;
 use cairo_lint::plugin::cairo_lint_allow_plugin_suite;
 use itertools::chain;
-use std::collections::HashSet;
-use std::path::PathBuf;
-use std::sync::Arc;
+
+use super::builtin_plugins::BuiltinPlugin;
+use crate::lang::db::AnalysisDatabase;
+use crate::project::model::PackageConfig;
 
 #[derive(Debug)]
 pub struct CrateInfo {

--- a/src/project/model/configs_registry/package_config_test.rs
+++ b/src/project/model/configs_registry/package_config_test.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 
 use crate::project::model::configs_registry::package_config::merge_serde_json_value;
 

--- a/src/project/model/mod.rs
+++ b/src/project/model/mod.rs
@@ -1,6 +1,9 @@
-use cairo_lang_filesystem::ids::CrateInput;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+
+use cairo_lang_filesystem::db::files_group_input;
+use cairo_lang_filesystem::ids::CrateInput;
+use salsa::Setter;
 
 pub use self::configs_registry::{ConfigsRegistry, PackageConfig};
 use crate::lang::db::AnalysisDatabase;
@@ -8,8 +11,6 @@ use crate::lang::proc_macros::controller::ProcMacroClientController;
 use crate::project::Crate;
 use crate::project::crate_data::CrateInfo;
 use crate::state::{Owned, Snapshot};
-use cairo_lang_filesystem::db::files_group_input;
-use salsa::Setter;
 
 mod configs_registry;
 

--- a/src/project/unmanaged_core_crate.rs
+++ b/src/project/unmanaged_core_crate.rs
@@ -7,6 +7,7 @@ use cairo_lang_filesystem::db::{
     CORELIB_CRATE_NAME, CORELIB_VERSION, FilesGroup, init_dev_corelib,
 };
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId};
+use cairo_lang_filesystem::set_crate_config;
 use cairo_lang_utils::Intern;
 use indoc::indoc;
 use semver::Version;
@@ -16,7 +17,6 @@ use tracing::{error, warn};
 use crate::config::Config;
 use crate::lang::db::AnalysisDatabase;
 use crate::toolchain::scarb::{SCARB_TOML, ScarbToolchain};
-use cairo_lang_filesystem::set_crate_config;
 
 /// Try to find a Cairo `core` crate (see [`find_unmanaged_core`]) and initialize it in the
 /// provided database.

--- a/tests/e2e/code_lens/executable.rs
+++ b/tests/e2e/code_lens/executable.rs
@@ -1,5 +1,6 @@
-use crate::code_lens::test_code_lens_scarb_execute;
 use indoc::indoc;
+
+use crate::code_lens::test_code_lens_scarb_execute;
 
 #[test]
 fn test_one_executable_whole_package() {

--- a/tests/e2e/external_tools_config.rs
+++ b/tests/e2e/external_tools_config.rs
@@ -1,4 +1,3 @@
-use crate::support::sandbox;
 use indoc::indoc;
 use lsp_types::notification::DidChangeWatchedFiles;
 use lsp_types::request::Formatting;
@@ -7,6 +6,8 @@ use lsp_types::{
     Range, TextEdit,
 };
 use serde_json::json;
+
+use crate::support::sandbox;
 
 #[test]
 fn lint_config_is_respected() {


### PR DESCRIPTION
## Rationale
I would like to enforce a strict format of imports.