### PR TITLE
Fix resultants

### DIFF
--- a/src/lang/db/semantic.rs
+++ b/src/lang/db/semantic.rs
@@ -634,10 +634,12 @@ fn find_generated_nodes<'db>(
                 let nodes: Vec<_> = terminal
                     .ancestors_with_self(db)
                     .map_while(|new_node| {
-                        translate_location(&mappings, new_node.span(db))
+                        translate_location(&mappings, new_node.span_without_trivia(db))
                             .map(|span_in_parent| (new_node, span_in_parent))
                     })
-                    .take_while(|(_, span_in_parent)| node.span(db).contains(*span_in_parent))
+                    .take_while(|(_, span_in_parent)| {
+                        node.span_without_trivia(db).contains(*span_in_parent)
+                    })
                     .collect();
 
                 if let Some((last_node, _)) = nodes.last().cloned() {

--- a/tests/e2e/code_actions/similar_member.rs
+++ b/tests/e2e/code_actions/similar_member.rs
@@ -182,3 +182,22 @@ fn typo_in_macro_call() {
     At: Range { start: Position { line: 7, character: 15 }, end: Position { line: 7, character: 21 } }
     "#);
 }
+
+#[test]
+fn typo_in_macro_call_with_trivia() {
+    test_transform!(quick_fix_with_macros, "
+    struct ElStructuro {
+        membero: felt252
+    }
+
+    #[test]
+    fn test_el_structuro() {
+        let x = ElStructuro { membero: 1 };
+        let _v = x.me<caret>mber + 1;
+    }
+    ", @r#"
+    Title: Use membero instead
+    Add new text: "membero"
+    At: Range { start: Position { line: 7, character: 15 }, end: Position { line: 7, character: 21 } }
+    "#);
+}


### PR DESCRIPTION
Span without trivias should be used, because otherwise it doesn't map back the nodes properly

Closes #1033 