### PR TITLE
Avoid panic on drop

### DIFF
--- a/src/lang/proc_macros/client/connection.rs
+++ b/src/lang/proc_macros/client/connection.rs
@@ -108,6 +108,6 @@ struct KillOnDrop(Child);
 impl Drop for KillOnDrop {
     fn drop(&mut self) {
         // Make sure server is closed.
-        self.0.kill().expect("failed to kill");
+        let _ = self.0.kill();
     }
 }


### PR DESCRIPTION
Panic in Drop handler will lead to SIGABRT without stack trace print