### PR TITLE
Support type hints for struct construction

### DIFF
--- a/src/ide/completion/dot_completions.rs
+++ b/src/ide/completion/dot_completions.rs
@@ -18,8 +18,7 @@ use lsp_types::{CompletionItem, CompletionItemKind, InsertTextFormat};
 use tracing::debug;
 
 use crate::ide::completion::helpers::binary_expr::dot_rhs::dot_expr_rhs;
-use crate::ide::completion::helpers::formatting::generate_abbreviated_signature;
-use crate::ide::completion::helpers::snippets::snippet_for_function_call;
+use crate::ide::completion::helpers::snippets::TypedSnippet;
 use crate::ide::completion::{CompletionItemOrderable, CompletionRelevance};
 use crate::ide::format::types::format_type;
 use crate::lang::analysis_context::AnalysisContext;
@@ -145,22 +144,20 @@ fn completion_for_method<'db>(
     let name = trait_function.name(db).to_string(db);
     let signature = db.trait_function_signature(trait_function).ok()?;
 
-    let abbreviated_signature =
-        generate_abbreviated_signature(db, signature, Some(trait_function.trait_id(db)));
-
     let mut additional_text_edits = vec![];
 
     // If the trait is not in scope, add a use statement.
     if let Some(edit) = import_edit_for_trait_if_needed(db, ctx, trait_id) {
         additional_text_edits.push(edit);
     }
+    let function_call_snippet = TypedSnippet::function_call(db, &name, signature, Some(trait_id));
 
     let completion = CompletionItemOrderable {
         item: CompletionItem {
             label: format!("{name}()"),
-            insert_text: Some(snippet_for_function_call(db, &name, signature)),
+            insert_text: Some(function_call_snippet.lsp_snippet),
             insert_text_format: Some(InsertTextFormat::SNIPPET),
-            detail: Some(abbreviated_signature),
+            detail: function_call_snippet.type_hint,
             kind: Some(CompletionItemKind::METHOD),
             additional_text_edits: Some(additional_text_edits),
             ..CompletionItem::default()

--- a/src/ide/completion/helpers/snippets.rs
+++ b/src/ide/completion/helpers/snippets.rs
@@ -1,27 +1,130 @@
+use cairo_lang_defs::ids::TraitId;
 use cairo_lang_semantic::Signature;
+use cairo_lang_semantic::diagnostic::SemanticDiagnostics;
+use cairo_lang_semantic::items::visibility::Visibility;
+use cairo_lang_semantic::lsp_helpers::LspHelpers;
+use cairo_lang_syntax::node::TypedSyntaxNode;
+use cairo_lang_syntax::node::ast::{ExprPath, ItemStruct, StatementExpr, StatementLet, TypeClause};
 use itertools::Itertools;
 
+use crate::ide::completion::helpers::formatting::generate_abbreviated_signature;
+use crate::lang::analysis_context::AnalysisContext;
 use crate::lang::db::AnalysisDatabase;
+use crate::lang::visibility::peek_visible_in_with_edition;
 
-/// Creates an LSP snippet for the function with the given name the signature.
-///
-/// Example: for a function with a signature
-/// ```cairo
-/// fn xyz(a: u8, b: ByteArray) -> felt252 {}
-/// ```
-/// returns a string "xyz({$1:a}, {$2:b})".
-pub fn snippet_for_function_call(
-    db: &AnalysisDatabase,
-    function_name: &str,
-    signature: &Signature,
-) -> String {
-    let params_snippet = signature
-        .params
-        .iter()
-        .map(|param| param.name.to_string(db))
-        .filter(|name| name != "self")
-        .enumerate()
-        .map(|(index, name)| format!("${{{}:{}}}", index + 1, name))
-        .join(", ");
-    format!("{function_name}({params_snippet})")
+#[derive(Clone)]
+pub struct TypedSnippet {
+    pub lsp_snippet: String,
+    pub type_hint: Option<String>,
+}
+
+impl TypedSnippet {
+    pub fn struct_initialization<'db>(
+        db: &'db AnalysisDatabase,
+        ctx: &AnalysisContext<'db>,
+        struct_node: ItemStruct<'db>,
+    ) -> Option<TypedSnippet> {
+        if (ctx.node.ancestor_of_type::<StatementLet>(db).is_none()
+            && ctx.node.ancestor_of_type::<StatementExpr>(db).is_none())
+            || ctx.node.ancestor_of_type::<ExprPath>(db).is_none()
+            || ctx.node.ancestor_of_type::<TypeClause>(db).is_some()
+        {
+            return None;
+        }
+
+        let struct_parent_module_id =
+            db.find_module_containing_node(struct_node.as_syntax_node())?;
+
+        let mut diagnostics = SemanticDiagnostics::default();
+
+        // If any field of the struct is not visible, we should not propose initialization.
+        if !struct_node.members(db).elements(db).all(|member| {
+            peek_visible_in_with_edition(
+                db,
+                Visibility::from_ast(db, &mut diagnostics, &member.visibility(db)),
+                struct_parent_module_id,
+                ctx.module_id,
+            )
+        }) {
+            return None;
+        }
+
+        let struct_name =
+            struct_node.name(db).as_syntax_node().get_text_without_trivia(db).long(db).as_str();
+
+        let type_hint = struct_node
+            .members(db)
+            .elements(db)
+            .map(|member| {
+                let member_name =
+                    member.name(db).as_syntax_node().get_text_without_trivia(db).long(db).as_str();
+                let member_type = member
+                    .type_clause(db)
+                    .as_syntax_node()
+                    .get_text_without_trivia(db)
+                    .long(db)
+                    .as_str();
+
+                format!("{}{}", member_name, member_type)
+            })
+            .join(", ");
+
+        let args = struct_node
+            .members(db)
+            .elements(db)
+            .enumerate()
+            .map(|(index, member)| {
+                format!(
+                    "{}: ${}",
+                    member.name(db).as_syntax_node().get_text_without_trivia(db).long(db).as_str(),
+                    // We use 1-based indexing for snippet placeholders, as the `0` is reserved for the final cursor position.
+                    index + 1,
+                )
+            })
+            .join(", ");
+
+        Some(if args.is_empty() {
+            let empty_initializer = format!("{} {{}}", struct_name);
+            TypedSnippet {
+                lsp_snippet: empty_initializer.clone(),
+                type_hint: Some(empty_initializer),
+            }
+        } else {
+            TypedSnippet {
+                lsp_snippet: format!("{} {{ {} }}", struct_name, args),
+                type_hint: Some(format!("{} {{ {} }}", struct_name, type_hint)),
+            }
+        })
+    }
+
+    /// Creates an LSP snippet for the function with the given name the signature.
+    ///
+    /// Example: for a function with a signature
+    /// ```cairo
+    /// fn xyz(a: u8, b: ByteArray) -> felt252 {}
+    /// ```
+    /// returns a string "xyz({$1:a}, {$2:b})".
+    pub fn function_call(
+        db: &AnalysisDatabase,
+        function_name: &str,
+        signature: &Signature,
+        trait_id: Option<TraitId>,
+    ) -> TypedSnippet {
+        let params_snippet = signature
+            .params
+            .iter()
+            .map(|param| param.name.to_string(db))
+            .filter(|name| name != "self")
+            .enumerate()
+            .map(|(index, name)| format!("${{{}:{}}}", index + 1, name))
+            .join(", ");
+        TypedSnippet {
+            lsp_snippet: format!("{function_name}({params_snippet})"),
+            type_hint: Some(generate_abbreviated_signature(db, signature, trait_id)),
+        }
+    }
+
+    pub fn macro_call(last_segment: &str) -> TypedSnippet {
+        TypedSnippet { lsp_snippet: format!("{}!($1)", last_segment), type_hint: None }
+    }
 }

--- a/src/ide/completion/mod.rs
+++ b/src/ide/completion/mod.rs
@@ -218,8 +218,8 @@ fn compare_items_by_label_and_detail(
             a_description.cmp(&b_description)
         })
         .then_with(|| {
-            let a_description = a.item.detail.clone();
-            let b_description = b.item.detail.clone();
+            let a_description = a.item.label_details.clone().unwrap_or_default().detail;
+            let b_description = b.item.label_details.clone().unwrap_or_default().detail;
             a_description.cmp(&b_description)
         })
 }

--- a/tests/e2e/completions/macros.rs
+++ b/tests/e2e/completions/macros.rs
@@ -29,16 +29,16 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "Option"
-    completion_label_path = "Option"
 
     [[completions]]
-    completion_label = "panic"
-    completion_label_path = "panic"
+    completion_label = "panic(...)"
+    completion_label_path = "(use panic)"
+    completion_label_type_info = "fn(data: Array<felt252>) -> crate::never"
     insert_text = "panic(${1:data})"
 
     [[completions]]
     completion_label = "WrappingAdd"
-    completion_label_path = "core::num::traits::WrappingAdd"
+    completion_label_path = "(use core::num::traits::WrappingAdd)"
     text_edits = ["""
     use core::num::traits::WrappingAdd;
 
@@ -46,7 +46,7 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "WrappingMul"
-    completion_label_path = "core::num::traits::WrappingMul"
+    completion_label_path = "(use core::num::traits::WrappingMul)"
     text_edits = ["""
     use core::num::traits::WrappingMul;
 
@@ -54,15 +54,16 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "WrappingSub"
-    completion_label_path = "core::num::traits::WrappingSub"
+    completion_label_path = "(use core::num::traits::WrappingSub)"
     text_edits = ["""
     use core::num::traits::WrappingSub;
 
     """]
 
     [[completions]]
-    completion_label = "min"
-    completion_label_path = "core::cmp::min"
+    completion_label = "min(...)"
+    completion_label_path = "(use core::cmp::min)"
+    completion_label_type_info = "fn(a: T, b: T) -> T"
     insert_text = "min(${1:a}, ${2:b})"
     text_edits = ["""
     use core::cmp::min;
@@ -71,15 +72,16 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "option"
-    completion_label_path = "core::option"
+    completion_label_path = "(use core::option)"
     text_edits = ["""
     use core::option;
 
     """]
 
     [[completions]]
-    completion_label = "print_byte_array_as_string"
-    completion_label_path = "core::debug::print_byte_array_as_string"
+    completion_label = "print_byte_array_as_string(...)"
+    completion_label_path = "(use core::debug::print_byte_array_as_string)"
+    completion_label_type_info = "fn(self: @ByteArray) -> ()"
     insert_text = "print_byte_array_as_string()"
     text_edits = ["""
     use core::debug::print_byte_array_as_string;
@@ -88,7 +90,7 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "string"
-    completion_label_path = "core::string"
+    completion_label_path = "(use core::string)"
     text_edits = ["""
     use core::string;
 
@@ -96,7 +98,7 @@ fn exp_inline_macro() {
 
     [[completions]]
     completion_label = "wrapping"
-    completion_label_path = "core::num::traits::ops::wrapping"
+    completion_label_path = "(use core::num::traits::ops::wrapping)"
     text_edits = ["""
     use core::num::traits::ops::wrapping;
 
@@ -118,8 +120,9 @@ fn exp_inline_macro_in_let_statement() {
     """
 
     [[completions]]
-    completion_label = "a"
-    completion_label_path = "a"
+    completion_label = "a(...)"
+    completion_label_path = "(use a)"
+    completion_label_type_info = "fn() -> ()"
     insert_text = "a()"
 
     [[completions]]
@@ -128,19 +131,16 @@ fn exp_inline_macro_in_let_statement() {
 
     [[completions]]
     completion_label = "Array"
-    completion_label_path = "Array"
 
     [[completions]]
     completion_label = "ArrayTrait"
-    completion_label_path = "ArrayTrait"
 
     [[completions]]
     completion_label = "Err"
-    completion_label_path = "Err"
 
     [[completions]]
     completion_label = "Err"
-    completion_label_path = "PanicResult::Err"
+    completion_label_path = "(use PanicResult::Err)"
     text_edits = ["""
     use PanicResult::Err;
 
@@ -148,7 +148,7 @@ fn exp_inline_macro_in_let_statement() {
 
     [[completions]]
     completion_label = "array"
-    completion_label_path = "core::array"
+    completion_label_path = "(use core::array)"
     text_edits = ["""
     use core::array;
 
@@ -156,7 +156,7 @@ fn exp_inline_macro_in_let_statement() {
 
     [[completions]]
     completion_label = "metaprogramming"
-    completion_label_path = "core::metaprogramming"
+    completion_label_path = "(use core::metaprogramming)"
     text_edits = ["""
     use core::metaprogramming;
 
@@ -338,19 +338,19 @@ fn partially_typed_top_level_macro_after_items() {
 
     [[completions]]
     completion_label = "core"
-    completion_label_path = "core"
 
     [[completions]]
     completion_label = "cmp"
-    completion_label_path = "core::cmp"
+    completion_label_path = "(use core::cmp)"
     text_edits = ["""
     use core::cmp;
 
     """]
 
     [[completions]]
-    completion_label = "compute_keccak_byte_array"
-    completion_label_path = "core::keccak::compute_keccak_byte_array"
+    completion_label = "compute_keccak_byte_array(...)"
+    completion_label_path = "(use core::keccak::compute_keccak_byte_array)"
+    completion_label_type_info = "fn(arr: @ByteArray) -> u256"
     insert_text = "compute_keccak_byte_array(${1:arr})"
     text_edits = ["""
     use core::keccak::compute_keccak_byte_array;
@@ -358,8 +358,9 @@ fn partially_typed_top_level_macro_after_items() {
     """]
 
     [[completions]]
-    completion_label = "compute_sha256_byte_array"
-    completion_label_path = "core::sha256::compute_sha256_byte_array"
+    completion_label = "compute_sha256_byte_array(...)"
+    completion_label_path = "(use core::sha256::compute_sha256_byte_array)"
+    completion_label_type_info = "fn(arr: @ByteArray) -> [u32; 8]"
     insert_text = "compute_sha256_byte_array(${1:arr})"
     text_edits = ["""
     use core::sha256::compute_sha256_byte_array;
@@ -367,8 +368,9 @@ fn partially_typed_top_level_macro_after_items() {
     """]
 
     [[completions]]
-    completion_label = "compute_sha256_u32_array"
-    completion_label_path = "core::sha256::compute_sha256_u32_array"
+    completion_label = "compute_sha256_u32_array(...)"
+    completion_label_path = "(use core::sha256::compute_sha256_u32_array)"
+    completion_label_type_info = "fn(input: Array<u32>, last_input_word: u32, last_input_num_bytes: u32) -> [u32; 8]"
     insert_text = "compute_sha256_u32_array(${1:input}, ${2:last_input_word}, ${3:last_input_num_bytes})"
     text_edits = ["""
     use core::sha256::compute_sha256_u32_array;
@@ -395,7 +397,7 @@ fn top_level_inline_macro() {
 
     [[completions]]
     completion_label = "my_own_macro!"
-    completion_label_path = "my_own_macro"
+    completion_label_path = "(use my_own_macro)"
     insert_text = "my_own_macro!($1)"
     "#);
 }

--- a/tests/e2e/completions/mod.rs
+++ b/tests/e2e/completions/mod.rs
@@ -126,7 +126,11 @@ fn transform(mut ls: MockClient, cursors: Cursors, main_file: &str) -> String {
             .into_iter()
             .map(|completion| Completions {
                 completion_label: completion.label,
-                completion_label_path: completion.label_details.unwrap_or_default().description,
+                completion_label_path: completion.label_details.clone().unwrap_or_default().detail,
+                completion_label_type_info: completion
+                    .label_details
+                    .unwrap_or_default()
+                    .description,
                 detail: completion.detail,
                 insert_text: completion.insert_text,
                 text_edits: completion
@@ -160,6 +164,8 @@ struct Completions {
     completion_label: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     completion_label_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completion_label_type_info: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/e2e/completions/order.rs
+++ b/tests/e2e/completions/order.rs
@@ -25,19 +25,16 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "AddAssign"
 
     [[completions]]
     completion_label = "AddAssignImpl"
-    completion_label_path = "AddAssignImpl"
 
     [[completions]]
     completion_label = "Add"
-    completion_label_path = "Add"
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "sub_module::AddAssign"
+    completion_label_path = "(use sub_module::AddAssign)"
     text_edits = ["""
     use sub_module::AddAssign;
 
@@ -45,7 +42,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "dep::AddAssign"
+    completion_label_path = "(use dep::AddAssign)"
     text_edits = ["""
     use dep::AddAssign;
 
@@ -53,7 +50,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "core::ops::AddAssign"
+    completion_label_path = "(use core::ops::AddAssign)"
     text_edits = ["""
     use core::ops::AddAssign;
 
@@ -61,7 +58,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddEq"
-    completion_label_path = "core::traits::AddEq"
+    completion_label_path = "(use core::traits::AddEq)"
     text_edits = ["""
     use core::traits::AddEq;
 
@@ -69,7 +66,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddInputResult"
-    completion_label_path = "core::circuit::AddInputResult"
+    completion_label_path = "(use core::circuit::AddInputResult)"
     text_edits = ["""
     use core::circuit::AddInputResult;
 
@@ -77,7 +74,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddInputResultImpl"
-    completion_label_path = "core::circuit::AddInputResultImpl"
+    completion_label_path = "(use core::circuit::AddInputResultImpl)"
     text_edits = ["""
     use core::circuit::AddInputResultImpl;
 
@@ -85,7 +82,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "AddMod"
-    completion_label_path = "core::circuit::AddMod"
+    completion_label_path = "(use core::circuit::AddMod)"
     text_edits = ["""
     use core::circuit::AddMod;
 
@@ -93,7 +90,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "DivAssign"
-    completion_label_path = "core::ops::DivAssign"
+    completion_label_path = "(use core::ops::DivAssign)"
     text_edits = ["""
     use core::ops::DivAssign;
 
@@ -101,7 +98,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "EthAddress"
-    completion_label_path = "starknet::EthAddress"
+    completion_label_path = "(use starknet::EthAddress)"
     text_edits = ["""
     use starknet::EthAddress;
 
@@ -109,7 +106,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "MulAssign"
-    completion_label_path = "core::ops::MulAssign"
+    completion_label_path = "(use core::ops::MulAssign)"
     text_edits = ["""
     use core::ops::MulAssign;
 
@@ -117,7 +114,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "RemAssign"
-    completion_label_path = "core::ops::RemAssign"
+    completion_label_path = "(use core::ops::RemAssign)"
     text_edits = ["""
     use core::ops::RemAssign;
 
@@ -125,7 +122,7 @@ fn order_with_current_crate_and_core_deps() {
 
     [[completions]]
     completion_label = "SubAssign"
-    completion_label_path = "core::ops::SubAssign"
+    completion_label_path = "(use core::ops::SubAssign)"
     text_edits = ["""
     use core::ops::SubAssign;
 
@@ -156,19 +153,16 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "AddAssign"
 
     [[completions]]
     completion_label = "AddAssignImpl"
-    completion_label_path = "AddAssignImpl"
 
     [[completions]]
     completion_label = "Add"
-    completion_label_path = "Add"
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "sub_module::AddAssign"
+    completion_label_path = "(use sub_module::AddAssign)"
     text_edits = ["""
     use sub_module::AddAssign;
 
@@ -176,7 +170,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "dep::AddAssign"
+    completion_label_path = "(use dep::AddAssign)"
     text_edits = ["""
     use dep::AddAssign;
 
@@ -184,7 +178,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddAssign"
-    completion_label_path = "core::ops::AddAssign"
+    completion_label_path = "(use core::ops::AddAssign)"
     text_edits = ["""
     use core::ops::AddAssign;
 
@@ -192,7 +186,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddEq"
-    completion_label_path = "core::traits::AddEq"
+    completion_label_path = "(use core::traits::AddEq)"
     text_edits = ["""
     use core::traits::AddEq;
 
@@ -200,7 +194,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddInputResult"
-    completion_label_path = "core::circuit::AddInputResult"
+    completion_label_path = "(use core::circuit::AddInputResult)"
     text_edits = ["""
     use core::circuit::AddInputResult;
 
@@ -208,7 +202,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddInputResultImpl"
-    completion_label_path = "core::circuit::AddInputResultImpl"
+    completion_label_path = "(use core::circuit::AddInputResultImpl)"
     text_edits = ["""
     use core::circuit::AddInputResultImpl;
 
@@ -216,7 +210,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "AddMod"
-    completion_label_path = "core::circuit::AddMod"
+    completion_label_path = "(use core::circuit::AddMod)"
     text_edits = ["""
     use core::circuit::AddMod;
 
@@ -224,7 +218,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "DivAssign"
-    completion_label_path = "core::ops::DivAssign"
+    completion_label_path = "(use core::ops::DivAssign)"
     text_edits = ["""
     use core::ops::DivAssign;
 
@@ -232,7 +226,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "EthAddress"
-    completion_label_path = "starknet::EthAddress"
+    completion_label_path = "(use starknet::EthAddress)"
     text_edits = ["""
     use starknet::EthAddress;
 
@@ -240,7 +234,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "MulAssign"
-    completion_label_path = "core::ops::MulAssign"
+    completion_label_path = "(use core::ops::MulAssign)"
     text_edits = ["""
     use core::ops::MulAssign;
 
@@ -248,7 +242,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "RemAssign"
-    completion_label_path = "core::ops::RemAssign"
+    completion_label_path = "(use core::ops::RemAssign)"
     text_edits = ["""
     use core::ops::RemAssign;
 
@@ -256,7 +250,7 @@ fn order_with_current_crate_and_core_deps_macros() {
 
     [[completions]]
     completion_label = "SubAssign"
-    completion_label_path = "core::ops::SubAssign"
+    completion_label_path = "(use core::ops::SubAssign)"
     text_edits = ["""
     use core::ops::SubAssign;
 
@@ -278,23 +272,19 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "ResultTraitCustom2"
-    completion_label_path = "ResultTraitCustom2"
 
     [[completions]]
     completion_label = "ResultTraitImpl"
-    completion_label_path = "ResultTraitImpl"
 
     [[completions]]
     completion_label = "Result"
-    completion_label_path = "Result"
 
     [[completions]]
     completion_label = "ResultTrait"
-    completion_label_path = "ResultTrait"
 
     [[completions]]
     completion_label = "ResultTraitCustom"
-    completion_label_path = "dep::ResultTraitCustom"
+    completion_label_path = "(use dep::ResultTraitCustom)"
     text_edits = ["""
     use dep::ResultTraitCustom;
 
@@ -302,7 +292,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "AddInputResultTrait"
-    completion_label_path = "core::circuit::AddInputResultTrait"
+    completion_label_path = "(use core::circuit::AddInputResultTrait)"
     text_edits = ["""
     use core::circuit::AddInputResultTrait;
 
@@ -310,7 +300,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "LoopResult"
-    completion_label_path = "core::internal::LoopResult"
+    completion_label_path = "(use core::internal::LoopResult)"
     text_edits = ["""
     use core::internal::LoopResult;
 
@@ -318,7 +308,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "RangeTrait"
-    completion_label_path = "core::ops::RangeTrait"
+    completion_label_path = "(use core::ops::RangeTrait)"
     text_edits = ["""
     use core::ops::RangeTrait;
 
@@ -326,7 +316,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "ResourceBounds"
-    completion_label_path = "starknet::ResourceBounds"
+    completion_label_path = "(use starknet::ResourceBounds)"
     text_edits = ["""
     use starknet::ResourceBounds;
 
@@ -334,7 +324,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "ResultTraitImpl"
-    completion_label_path = "core::result::ResultTraitImpl"
+    completion_label_path = "(use core::result::ResultTraitImpl)"
     text_edits = ["""
     use core::result::ResultTraitImpl;
 
@@ -342,7 +332,7 @@ fn prelude_ordering() {
 
     [[completions]]
     completion_label = "result"
-    completion_label_path = "core::result"
+    completion_label_path = "(use core::result)"
     text_edits = ["""
     use core::result;
 

--- a/tests/e2e/completions/path.rs
+++ b/tests/e2e/completions/path.rs
@@ -19,29 +19,26 @@ fn single_element_path() {
     """
 
     [[completions]]
-    completion_label = "ByteA_ActuallyNotByteArray"
-    completion_label_path = "ByteA_ActuallyNotByteArray"
+    completion_label = "ByteA_ActuallyNotByteArray {...}"
+    completion_label_path = "(use ByteA_ActuallyNotByteArray)"
+    completion_label_type_info = "ByteA_ActuallyNotByteArray {}"
     insert_text = "ByteA_ActuallyNotByteArray {}"
 
     [[completions]]
     completion_label = "ByteArray"
-    completion_label_path = "ByteArray"
 
     [[completions]]
     completion_label = "ByteArrayTrait"
-    completion_label_path = "ByteArrayTrait"
 
     [[completions]]
     completion_label = "Bytes31Trait"
-    completion_label_path = "Bytes31Trait"
 
     [[completions]]
     completion_label = "System"
-    completion_label_path = "System"
 
     [[completions]]
     completion_label = "BitAnd"
-    completion_label_path = "core::traits::BitAnd"
+    completion_label_path = "(use core::traits::BitAnd)"
     text_edits = ["""
     use core::traits::BitAnd;
 
@@ -49,7 +46,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteArrayImpl"
-    completion_label_path = "core::byte_array::ByteArrayImpl"
+    completion_label_path = "(use core::byte_array::ByteArrayImpl)"
     text_edits = ["""
     use core::byte_array::ByteArrayImpl;
 
@@ -57,7 +54,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteArrayIter"
-    completion_label_path = "core::byte_array::ByteArrayIter"
+    completion_label_path = "(use core::byte_array::ByteArrayIter)"
     text_edits = ["""
     use core::byte_array::ByteArrayIter;
 
@@ -65,7 +62,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteSpan"
-    completion_label_path = "core::byte_array::ByteSpan"
+    completion_label_path = "(use core::byte_array::ByteSpan)"
     text_edits = ["""
     use core::byte_array::ByteSpan;
 
@@ -73,7 +70,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteSpanImpl"
-    completion_label_path = "core::byte_array::ByteSpanImpl"
+    completion_label_path = "(use core::byte_array::ByteSpanImpl)"
     text_edits = ["""
     use core::byte_array::ByteSpanImpl;
 
@@ -81,7 +78,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteSpanIter"
-    completion_label_path = "core::byte_array::ByteSpanIter"
+    completion_label_path = "(use core::byte_array::ByteSpanIter)"
     text_edits = ["""
     use core::byte_array::ByteSpanIter;
 
@@ -89,7 +86,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "ByteSpanTrait"
-    completion_label_path = "core::byte_array::ByteSpanTrait"
+    completion_label_path = "(use core::byte_array::ByteSpanTrait)"
     text_edits = ["""
     use core::byte_array::ByteSpanTrait;
 
@@ -97,7 +94,7 @@ fn single_element_path() {
 
     [[completions]]
     completion_label = "Bytes31Impl"
-    completion_label_path = "core::bytes_31::Bytes31Impl"
+    completion_label_path = "(use core::bytes_31::Bytes31Impl)"
     text_edits = ["""
     use core::bytes_31::Bytes31Impl;
 
@@ -122,8 +119,9 @@ fn multi_segment_path() {
     """
 
     [[completions]]
-    completion_label = "Baz"
-    completion_label_path = "foo::Baz"
+    completion_label = "Baz {...}"
+    completion_label_path = "(use foo::Baz)"
+    completion_label_type_info = "Baz {}"
     insert_text = "Baz {}"
     "#);
 }
@@ -147,8 +145,9 @@ fn multi_segment_path_partial() {
     """
 
     [[completions]]
-    completion_label = "Baz"
-    completion_label_path = "foo::bar::Baz"
+    completion_label = "Baz {...}"
+    completion_label_path = "(use foo::bar::Baz)"
+    completion_label_type_info = "Baz {}"
     insert_text = "Baz {}"
     text_edits = ["""
     use foo::bar;
@@ -177,8 +176,9 @@ fn multi_segment_path_partial_macro() {
     """
 
     [[completions]]
-    completion_label = "Baz"
-    completion_label_path = "foo::bar::Baz"
+    completion_label = "Baz {...}"
+    completion_label_path = "(use foo::bar::Baz)"
+    completion_label_type_info = "Baz {}"
     insert_text = "Baz {}"
     text_edits = ["""
     use foo::bar;
@@ -205,11 +205,11 @@ fn enum_variant() {
 
     [[completions]]
     completion_label = "A"
-    completion_label_path = "Enumik::A"
+    completion_label_path = "(use Enumik::A)"
 
     [[completions]]
     completion_label = "B"
-    completion_label_path = "Enumik::B"
+    completion_label_path = "(use Enumik::B)"
     "#);
 }
 
@@ -231,11 +231,11 @@ fn type_annotation() {
 
     [[completions]]
     completion_label = "felt"
-    completion_label_path = "module::felt"
+    completion_label_path = "(use module::felt)"
 
     [[completions]]
     completion_label = "int"
-    completion_label_path = "module::int"
+    completion_label_path = "(use module::int)"
     "#);
 }
 
@@ -264,19 +264,19 @@ fn type_annotation_with_dangling_path() {
 
     [[completions]]
     completion_label = "CONST"
-    completion_label_path = "module::CONST"
+    completion_label_path = "(use module::CONST)"
 
     [[completions]]
     completion_label = "felt"
-    completion_label_path = "module::felt"
+    completion_label_path = "(use module::felt)"
 
     [[completions]]
     completion_label = "int"
-    completion_label_path = "module::int"
+    completion_label_path = "(use module::int)"
 
     [[completions]]
     completion_label = "nested_module"
-    completion_label_path = "module::nested_module"
+    completion_label_path = "(use module::nested_module)"
     "#);
 }
 
@@ -299,11 +299,11 @@ fn type_annotation_with_trivia() {
 
     [[completions]]
     completion_label = "felt"
-    completion_label_path = "module::felt"
+    completion_label_path = "(use module::felt)"
 
     [[completions]]
     completion_label = "int"
-    completion_label_path = "module::int"
+    completion_label_path = "(use module::int)"
     "#);
 }
 
@@ -325,11 +325,11 @@ fn generic_parameter() {
 
     [[completions]]
     completion_label = "felt"
-    completion_label_path = "module::felt"
+    completion_label_path = "(use module::felt)"
 
     [[completions]]
     completion_label = "int"
-    completion_label_path = "module::int"
+    completion_label_path = "(use module::int)"
     "#);
 }
 
@@ -352,11 +352,11 @@ fn generic_parameter_with_trivia() {
 
     [[completions]]
     completion_label = "felt"
-    completion_label_path = "module::felt"
+    completion_label_path = "(use module::felt)"
 
     [[completions]]
     completion_label = "int"
-    completion_label_path = "module::int"
+    completion_label_path = "(use module::int)"
     "#);
 }
 
@@ -371,7 +371,7 @@ fn function_implicit_parameter() {
 
     [[completions]]
     completion_label = "RangeCheck"
-    completion_label_path = "core::RangeCheck"
+    completion_label_path = "(use core::RangeCheck)"
     "#);
 }
 
@@ -391,8 +391,9 @@ fn simple_completion_without_explicit_path() {
     """
 
     [[completions]]
-    completion_label = "xyz"
-    completion_label_path = "a::xyz"
+    completion_label = "xyz(...)"
+    completion_label_path = "(use a::xyz)"
+    completion_label_type_info = "fn() -> ()"
     insert_text = "xyz()"
     text_edits = ["""
     use a::xyz;
@@ -421,8 +422,9 @@ fn duplicated_completion_without_explicit_path() {
     """
 
     [[completions]]
-    completion_label = "xyz"
-    completion_label_path = "a::xyz"
+    completion_label = "xyz(...)"
+    completion_label_path = "(use a::xyz)"
+    completion_label_type_info = "fn() -> ()"
     insert_text = "xyz()"
     text_edits = ["""
     use a::xyz;
@@ -430,8 +432,9 @@ fn duplicated_completion_without_explicit_path() {
     """]
 
     [[completions]]
-    completion_label = "xyz"
-    completion_label_path = "b::xyz"
+    completion_label = "xyz(...)"
+    completion_label_path = "(use b::xyz)"
+    completion_label_type_info = "fn() -> ()"
     insert_text = "xyz()"
     text_edits = ["""
     use b::xyz;
@@ -475,11 +478,12 @@ fn no_text_last_segment_in_function_context() {
 
     [[completions]]
     completion_label = "MY_CONST"
-    completion_label_path = "my_mod::MY_CONST"
+    completion_label_path = "(use my_mod::MY_CONST)"
 
     [[completions]]
-    completion_label = "my_func"
-    completion_label_path = "my_mod::my_func"
+    completion_label = "my_func(...)"
+    completion_label_path = "(use my_mod::my_func)"
+    completion_label_type_info = "fn() -> ()"
     insert_text = "my_func()"
     "#);
 }
@@ -503,7 +507,7 @@ fn simple_declarative_macro_completion() {
 
     [[completions]]
     completion_label = "my_own_macro!"
-    completion_label_path = "my_own_macro"
+    completion_label_path = "(use my_own_macro)"
     insert_text = "my_own_macro!($1)"
     "#);
 }
@@ -529,11 +533,10 @@ fn declarative_macro_completion_without_explicit_path() {
 
     [[completions]]
     completion_label = "my_mod"
-    completion_label_path = "my_mod"
 
     [[completions]]
     completion_label = "my_own_macro!"
-    completion_label_path = "my_mod::my_own_macro"
+    completion_label_path = "(use my_mod::my_own_macro)"
     insert_text = "my_own_macro!($1)"
     text_edits = ["""
     use my_mod::my_own_macro;

--- a/tests/e2e/completions/structs.rs
+++ b/tests/e2e/completions/structs.rs
@@ -393,17 +393,18 @@ fn basic_initialization() {
     """
 
     [[completions]]
-    completion_label = "Abc"
-    completion_label_path = "Abc"
+    completion_label = "Abc {...}"
+    completion_label_path = "(use Abc)"
+    completion_label_type_info = "Abc { a: u128, b: u128, c: u128 }"
     insert_text = "Abc { a: $1, b: $2, c: $3 }"
 
     [[completions]]
     completion_label = "AbcDrop"
-    completion_label_path = "AbcDrop"
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointers"
+    completion_label = "AccountContractLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointers;
@@ -411,8 +412,12 @@ fn basic_initialization() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointersMut;
@@ -420,8 +425,9 @@ fn basic_initialization() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointers"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointers;
@@ -429,8 +435,12 @@ fn basic_initialization() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut;
@@ -460,8 +470,9 @@ fn initialization_non_imported_struct() {
     """
 
     [[completions]]
-    completion_label = "Abc"
-    completion_label_path = "m::Abc"
+    completion_label = "Abc {...}"
+    completion_label_path = "(use m::Abc)"
+    completion_label_type_info = "Abc { a: u128, b: u128, c: u128 }"
     insert_text = "Abc { a: $1, b: $2, c: $3 }"
     text_edits = ["""
     use m::Abc;
@@ -469,8 +480,9 @@ fn initialization_non_imported_struct() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointers"
+    completion_label = "AccountContractLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointers;
@@ -478,8 +490,12 @@ fn initialization_non_imported_struct() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointersMut;
@@ -487,8 +503,9 @@ fn initialization_non_imported_struct() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointers"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointers;
@@ -496,8 +513,12 @@ fn initialization_non_imported_struct() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut;
@@ -526,17 +547,18 @@ fn initialization_with_macro() {
     """
 
     [[completions]]
-    completion_label = "Abc"
-    completion_label_path = "Abc"
+    completion_label = "Abc {...}"
+    completion_label_path = "(use Abc)"
+    completion_label_type_info = "Abc { a: u128, b: u128, c: u128 }"
     insert_text = "Abc { a: $1, b: $2, c: $3 }"
 
     [[completions]]
     completion_label = "AbcDrop"
-    completion_label_path = "AbcDrop"
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointers"
+    completion_label = "AccountContractLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointers;
@@ -544,8 +566,12 @@ fn initialization_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointersMut;
@@ -553,8 +579,9 @@ fn initialization_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointers"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointers;
@@ -562,8 +589,12 @@ fn initialization_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut;
@@ -594,8 +625,9 @@ fn initialization_non_imported_struct_with_macro() {
     """
 
     [[completions]]
-    completion_label = "Abc"
-    completion_label_path = "m::Abc"
+    completion_label = "Abc {...}"
+    completion_label_path = "(use m::Abc)"
+    completion_label_type_info = "Abc { a: u128, b: u128, c: u128 }"
     insert_text = "Abc { a: $1, b: $2, c: $3 }"
     text_edits = ["""
     use m::Abc;
@@ -603,8 +635,9 @@ fn initialization_non_imported_struct_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointers"
+    completion_label = "AccountContractLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointers;
@@ -612,8 +645,12 @@ fn initialization_non_imported_struct_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointersMut;
@@ -621,8 +658,9 @@ fn initialization_non_imported_struct_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointers"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointers {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointers)"
+    completion_label_type_info = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: starknet::storage::StoragePointer<starknet::ClassHash> }"
     insert_text = "AccountContractSafeLibraryDispatcherSubPointers { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointers;
@@ -630,8 +668,12 @@ fn initialization_non_imported_struct_with_macro() {
     """]
 
     [[completions]]
-    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut"
+    completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut {...}"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut)"
+    completion_label_type_info = """
+    AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: starknet::storage::StoragePointer<
+            starknet::storage::Mutable<starknet::ClassHash>,
+        > }"""
     insert_text = "AccountContractSafeLibraryDispatcherSubPointersMut { class_hash: $1 }"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut;
@@ -659,11 +701,10 @@ fn no_initialization_completion_for_types_in_closures() {
 
     [[completions]]
     completion_label = "Abc"
-    completion_label_path = "Abc"
 
     [[completions]]
     completion_label = "AccountContractLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointers"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointers)"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointers;
 
@@ -671,7 +712,7 @@ fn no_initialization_completion_for_types_in_closures() {
 
     [[completions]]
     completion_label = "AccountContractLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractLibraryDispatcherSubPointersMut"
+    completion_label_path = "(use starknet::account::AccountContractLibraryDispatcherSubPointersMut)"
     text_edits = ["""
     use starknet::account::AccountContractLibraryDispatcherSubPointersMut;
 
@@ -679,7 +720,7 @@ fn no_initialization_completion_for_types_in_closures() {
 
     [[completions]]
     completion_label = "AccountContractSafeLibraryDispatcherSubPointers"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointers"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointers)"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointers;
 
@@ -687,7 +728,7 @@ fn no_initialization_completion_for_types_in_closures() {
 
     [[completions]]
     completion_label = "AccountContractSafeLibraryDispatcherSubPointersMut"
-    completion_label_path = "starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut"
+    completion_label_path = "(use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut)"
     text_edits = ["""
     use starknet::account::AccountContractSafeLibraryDispatcherSubPointersMut;
 

--- a/tests/e2e/completions/traits.rs
+++ b/tests/e2e/completions/traits.rs
@@ -83,31 +83,25 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "Default"
-    completion_label_path = "Default"
 
     [[completions]]
     completion_label = "Deref"
-    completion_label_path = "Deref"
 
     [[completions]]
     completion_label = "Destruct"
-    completion_label_path = "Destruct"
 
     [[completions]]
     completion_label = "Div"
-    completion_label_path = "Div"
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "DivRem"
 
     [[completions]]
     completion_label = "Drop"
-    completion_label_path = "Drop"
 
     [[completions]]
     completion_label = "Debug"
-    completion_label_path = "core::fmt::Debug"
+    completion_label_path = "(use core::fmt::Debug)"
     text_edits = ["""
     use core::fmt::Debug;
 
@@ -115,7 +109,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DebugImpl"
-    completion_label_path = "core::fmt::into_felt252_based::DebugImpl"
+    completion_label_path = "(use core::fmt::into_felt252_based::DebugImpl)"
     text_edits = ["""
     use core::fmt::into_felt252_based::DebugImpl;
 
@@ -123,7 +117,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DeploymentParams"
-    completion_label_path = "starknet::deployment::DeploymentParams"
+    completion_label_path = "(use starknet::deployment::DeploymentParams)"
     text_edits = ["""
     use starknet::deployment::DeploymentParams;
 
@@ -131,7 +125,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DerefMut"
-    completion_label_path = "core::ops::DerefMut"
+    completion_label_path = "(use core::ops::DerefMut)"
     text_edits = ["""
     use core::ops::DerefMut;
 
@@ -139,7 +133,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DestructFailureGuarantee"
-    completion_label_path = "core::circuit::DestructFailureGuarantee"
+    completion_label_path = "(use core::circuit::DestructFailureGuarantee)"
     text_edits = ["""
     use core::circuit::DestructFailureGuarantee;
 
@@ -147,7 +141,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DestructOption"
-    completion_label_path = "core::option::DestructOption"
+    completion_label_path = "(use core::option::DestructOption)"
     text_edits = ["""
     use core::option::DestructOption;
 
@@ -155,7 +149,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DestructWith"
-    completion_label_path = "core::internal::DestructWith"
+    completion_label_path = "(use core::internal::DestructWith)"
     text_edits = ["""
     use core::internal::DestructWith;
 
@@ -163,7 +157,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "Display"
-    completion_label_path = "core::fmt::Display"
+    completion_label_path = "(use core::fmt::Display)"
     text_edits = ["""
     use core::fmt::Display;
 
@@ -171,7 +165,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DivAssign"
-    completion_label_path = "core::ops::DivAssign"
+    completion_label_path = "(use core::ops::DivAssign)"
     text_edits = ["""
     use core::ops::DivAssign;
 
@@ -179,7 +173,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DivEq"
-    completion_label_path = "core::traits::DivEq"
+    completion_label_path = "(use core::traits::DivEq)"
     text_edits = ["""
     use core::traits::DivEq;
 
@@ -187,7 +181,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "core::num::traits::DivRem"
+    completion_label_path = "(use core::num::traits::DivRem)"
     text_edits = ["""
     use core::num::traits::DivRem;
 
@@ -195,7 +189,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DivRemHelper"
-    completion_label_path = "core::internal::bounded_int::DivRemHelper"
+    completion_label_path = "(use core::internal::bounded_int::DivRemHelper)"
     text_edits = ["""
     use core::internal::bounded_int::DivRemHelper;
 
@@ -203,7 +197,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "Done"
-    completion_label_path = "core::circuit::AddInputResult::Done"
+    completion_label_path = "(use core::circuit::AddInputResult::Done)"
     text_edits = ["""
     use core::circuit::AddInputResult::Done;
 
@@ -211,7 +205,7 @@ fn type_bound() {
 
     [[completions]]
     completion_label = "DropWith"
-    completion_label_path = "core::internal::DropWith"
+    completion_label_path = "(use core::internal::DropWith)"
     text_edits = ["""
     use core::internal::DropWith;
 
@@ -231,31 +225,25 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "Default"
-    completion_label_path = "Default"
 
     [[completions]]
     completion_label = "Deref"
-    completion_label_path = "Deref"
 
     [[completions]]
     completion_label = "Destruct"
-    completion_label_path = "Destruct"
 
     [[completions]]
     completion_label = "Div"
-    completion_label_path = "Div"
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "DivRem"
 
     [[completions]]
     completion_label = "Drop"
-    completion_label_path = "Drop"
 
     [[completions]]
     completion_label = "Debug"
-    completion_label_path = "core::fmt::Debug"
+    completion_label_path = "(use core::fmt::Debug)"
     text_edits = ["""
     use core::fmt::Debug;
 
@@ -263,7 +251,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DebugImpl"
-    completion_label_path = "core::fmt::into_felt252_based::DebugImpl"
+    completion_label_path = "(use core::fmt::into_felt252_based::DebugImpl)"
     text_edits = ["""
     use core::fmt::into_felt252_based::DebugImpl;
 
@@ -271,7 +259,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DeploymentParams"
-    completion_label_path = "starknet::deployment::DeploymentParams"
+    completion_label_path = "(use starknet::deployment::DeploymentParams)"
     text_edits = ["""
     use starknet::deployment::DeploymentParams;
 
@@ -279,7 +267,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DerefMut"
-    completion_label_path = "core::ops::DerefMut"
+    completion_label_path = "(use core::ops::DerefMut)"
     text_edits = ["""
     use core::ops::DerefMut;
 
@@ -287,7 +275,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DestructFailureGuarantee"
-    completion_label_path = "core::circuit::DestructFailureGuarantee"
+    completion_label_path = "(use core::circuit::DestructFailureGuarantee)"
     text_edits = ["""
     use core::circuit::DestructFailureGuarantee;
 
@@ -295,7 +283,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DestructOption"
-    completion_label_path = "core::option::DestructOption"
+    completion_label_path = "(use core::option::DestructOption)"
     text_edits = ["""
     use core::option::DestructOption;
 
@@ -303,7 +291,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DestructWith"
-    completion_label_path = "core::internal::DestructWith"
+    completion_label_path = "(use core::internal::DestructWith)"
     text_edits = ["""
     use core::internal::DestructWith;
 
@@ -311,7 +299,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "Display"
-    completion_label_path = "core::fmt::Display"
+    completion_label_path = "(use core::fmt::Display)"
     text_edits = ["""
     use core::fmt::Display;
 
@@ -319,7 +307,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DivAssign"
-    completion_label_path = "core::ops::DivAssign"
+    completion_label_path = "(use core::ops::DivAssign)"
     text_edits = ["""
     use core::ops::DivAssign;
 
@@ -327,7 +315,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DivEq"
-    completion_label_path = "core::traits::DivEq"
+    completion_label_path = "(use core::traits::DivEq)"
     text_edits = ["""
     use core::traits::DivEq;
 
@@ -335,7 +323,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "core::num::traits::DivRem"
+    completion_label_path = "(use core::num::traits::DivRem)"
     text_edits = ["""
     use core::num::traits::DivRem;
 
@@ -343,7 +331,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DivRemHelper"
-    completion_label_path = "core::internal::bounded_int::DivRemHelper"
+    completion_label_path = "(use core::internal::bounded_int::DivRemHelper)"
     text_edits = ["""
     use core::internal::bounded_int::DivRemHelper;
 
@@ -351,7 +339,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "Done"
-    completion_label_path = "core::circuit::AddInputResult::Done"
+    completion_label_path = "(use core::circuit::AddInputResult::Done)"
     text_edits = ["""
     use core::circuit::AddInputResult::Done;
 
@@ -359,7 +347,7 @@ fn negative_type_bound() {
 
     [[completions]]
     completion_label = "DropWith"
-    completion_label_path = "core::internal::DropWith"
+    completion_label_path = "(use core::internal::DropWith)"
     text_edits = ["""
     use core::internal::DropWith;
 
@@ -378,31 +366,25 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "Default"
-    completion_label_path = "Default"
 
     [[completions]]
     completion_label = "Deref"
-    completion_label_path = "Deref"
 
     [[completions]]
     completion_label = "Destruct"
-    completion_label_path = "Destruct"
 
     [[completions]]
     completion_label = "Div"
-    completion_label_path = "Div"
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "DivRem"
 
     [[completions]]
     completion_label = "Drop"
-    completion_label_path = "Drop"
 
     [[completions]]
     completion_label = "Debug"
-    completion_label_path = "core::fmt::Debug"
+    completion_label_path = "(use core::fmt::Debug)"
     text_edits = ["""
     use core::fmt::Debug;
 
@@ -410,7 +392,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DebugImpl"
-    completion_label_path = "core::fmt::into_felt252_based::DebugImpl"
+    completion_label_path = "(use core::fmt::into_felt252_based::DebugImpl)"
     text_edits = ["""
     use core::fmt::into_felt252_based::DebugImpl;
 
@@ -418,7 +400,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DeploymentParams"
-    completion_label_path = "starknet::deployment::DeploymentParams"
+    completion_label_path = "(use starknet::deployment::DeploymentParams)"
     text_edits = ["""
     use starknet::deployment::DeploymentParams;
 
@@ -426,7 +408,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DerefMut"
-    completion_label_path = "core::ops::DerefMut"
+    completion_label_path = "(use core::ops::DerefMut)"
     text_edits = ["""
     use core::ops::DerefMut;
 
@@ -434,7 +416,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DestructFailureGuarantee"
-    completion_label_path = "core::circuit::DestructFailureGuarantee"
+    completion_label_path = "(use core::circuit::DestructFailureGuarantee)"
     text_edits = ["""
     use core::circuit::DestructFailureGuarantee;
 
@@ -442,7 +424,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DestructOption"
-    completion_label_path = "core::option::DestructOption"
+    completion_label_path = "(use core::option::DestructOption)"
     text_edits = ["""
     use core::option::DestructOption;
 
@@ -450,7 +432,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DestructWith"
-    completion_label_path = "core::internal::DestructWith"
+    completion_label_path = "(use core::internal::DestructWith)"
     text_edits = ["""
     use core::internal::DestructWith;
 
@@ -458,7 +440,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "Display"
-    completion_label_path = "core::fmt::Display"
+    completion_label_path = "(use core::fmt::Display)"
     text_edits = ["""
     use core::fmt::Display;
 
@@ -466,7 +448,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DivAssign"
-    completion_label_path = "core::ops::DivAssign"
+    completion_label_path = "(use core::ops::DivAssign)"
     text_edits = ["""
     use core::ops::DivAssign;
 
@@ -474,7 +456,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DivEq"
-    completion_label_path = "core::traits::DivEq"
+    completion_label_path = "(use core::traits::DivEq)"
     text_edits = ["""
     use core::traits::DivEq;
 
@@ -482,7 +464,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DivRem"
-    completion_label_path = "core::num::traits::DivRem"
+    completion_label_path = "(use core::num::traits::DivRem)"
     text_edits = ["""
     use core::num::traits::DivRem;
 
@@ -490,7 +472,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DivRemHelper"
-    completion_label_path = "core::internal::bounded_int::DivRemHelper"
+    completion_label_path = "(use core::internal::bounded_int::DivRemHelper)"
     text_edits = ["""
     use core::internal::bounded_int::DivRemHelper;
 
@@ -498,7 +480,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "Done"
-    completion_label_path = "core::circuit::AddInputResult::Done"
+    completion_label_path = "(use core::circuit::AddInputResult::Done)"
     text_edits = ["""
     use core::circuit::AddInputResult::Done;
 
@@ -506,7 +488,7 @@ fn impl_bound() {
 
     [[completions]]
     completion_label = "DropWith"
-    completion_label_path = "core::internal::DropWith"
+    completion_label_path = "(use core::internal::DropWith)"
     text_edits = ["""
     use core::internal::DropWith;
 
@@ -526,15 +508,13 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "Traicik"
-    completion_label_path = "Traicik"
 
     [[completions]]
     completion_label = "BoxTrait"
-    completion_label_path = "BoxTrait"
 
     [[completions]]
     completion_label = "ResultTraitImpl"
-    completion_label_path = "core::result::ResultTraitImpl"
+    completion_label_path = "(use core::result::ResultTraitImpl)"
     text_edits = ["""
     use core::result::ResultTraitImpl;
 
@@ -542,7 +522,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "TrimMaxHelper"
-    completion_label_path = "core::internal::bounded_int::TrimMaxHelper"
+    completion_label_path = "(use core::internal::bounded_int::TrimMaxHelper)"
     text_edits = ["""
     use core::internal::bounded_int::TrimMaxHelper;
 
@@ -550,7 +530,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "TrimMinHelper"
-    completion_label_path = "core::internal::bounded_int::TrimMinHelper"
+    completion_label_path = "(use core::internal::bounded_int::TrimMinHelper)"
     text_edits = ["""
     use core::internal::bounded_int::TrimMinHelper;
 
@@ -558,7 +538,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "True"
-    completion_label_path = "bool::True"
+    completion_label_path = "(use bool::True)"
     text_edits = ["""
     use bool::True;
 
@@ -566,7 +546,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "VecTrait"
-    completion_label_path = "starknet::storage::VecTrait"
+    completion_label_path = "(use starknet::storage::VecTrait)"
     text_edits = ["""
     use starknet::storage::VecTrait;
 
@@ -574,7 +554,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "traits"
-    completion_label_path = "core::num::traits"
+    completion_label_path = "(use core::num::traits)"
     text_edits = ["""
     use core::num::traits;
 
@@ -582,7 +562,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "traits"
-    completion_label_path = "core::traits"
+    completion_label_path = "(use core::traits)"
     text_edits = ["""
     use core::traits;
 
@@ -590,7 +570,7 @@ fn type_bound_user_trait() {
 
     [[completions]]
     completion_label = "wrapping"
-    completion_label_path = "core::num::traits::ops::wrapping"
+    completion_label_path = "(use core::num::traits::ops::wrapping)"
     text_edits = ["""
     use core::num::traits::ops::wrapping;
 

--- a/tests/e2e/completions/vars_and_params.rs
+++ b/tests/e2e/completions/vars_and_params.rs
@@ -31,15 +31,16 @@ fn all_prefixed() {
 
     [[completions]]
     completion_label = "blake"
-    completion_label_path = "core::blake"
+    completion_label_path = "(use core::blake)"
     text_edits = ["""
     use core::blake;
 
     """]
 
     [[completions]]
-    completion_label = "blake2s_compress"
-    completion_label_path = "core::blake::blake2s_compress"
+    completion_label = "blake2s_compress(...)"
+    completion_label_path = "(use core::blake::blake2s_compress)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_compress(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_compress;
@@ -47,8 +48,9 @@ fn all_prefixed() {
     """]
 
     [[completions]]
-    completion_label = "blake2s_finalize"
-    completion_label_path = "core::blake::blake2s_finalize"
+    completion_label = "blake2s_finalize(...)"
+    completion_label_path = "(use core::blake::blake2s_finalize)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_finalize(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_finalize;
@@ -57,15 +59,16 @@ fn all_prefixed() {
 
     [[completions]]
     completion_label = "byte_array"
-    completion_label_path = "core::byte_array"
+    completion_label_path = "(use core::byte_array)"
     text_edits = ["""
     use core::byte_array;
 
     """]
 
     [[completions]]
-    completion_label = "library_call_syscall"
-    completion_label_path = "starknet::syscalls::library_call_syscall"
+    completion_label = "library_call_syscall(...)"
+    completion_label_path = "(use starknet::syscalls::library_call_syscall)"
+    completion_label_type_info = "fn(class_hash: ClassHash, function_selector: felt252, calldata: Span<felt252>) -> Result<Span<felt252>, Array<felt252>> nopanic"
     insert_text = "library_call_syscall(${1:class_hash}, ${2:function_selector}, ${3:calldata})"
     text_edits = ["""
     use starknet::syscalls::library_call_syscall;
@@ -101,15 +104,16 @@ fn all_prefixed_macro() {
 
     [[completions]]
     completion_label = "blake"
-    completion_label_path = "core::blake"
+    completion_label_path = "(use core::blake)"
     text_edits = ["""
     use core::blake;
 
     """]
 
     [[completions]]
-    completion_label = "blake2s_compress"
-    completion_label_path = "core::blake::blake2s_compress"
+    completion_label = "blake2s_compress(...)"
+    completion_label_path = "(use core::blake::blake2s_compress)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_compress(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_compress;
@@ -117,8 +121,9 @@ fn all_prefixed_macro() {
     """]
 
     [[completions]]
-    completion_label = "blake2s_finalize"
-    completion_label_path = "core::blake::blake2s_finalize"
+    completion_label = "blake2s_finalize(...)"
+    completion_label_path = "(use core::blake::blake2s_finalize)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_finalize(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_finalize;
@@ -127,15 +132,16 @@ fn all_prefixed_macro() {
 
     [[completions]]
     completion_label = "byte_array"
-    completion_label_path = "core::byte_array"
+    completion_label_path = "(use core::byte_array)"
     text_edits = ["""
     use core::byte_array;
 
     """]
 
     [[completions]]
-    completion_label = "library_call_syscall"
-    completion_label_path = "starknet::syscalls::library_call_syscall"
+    completion_label = "library_call_syscall(...)"
+    completion_label_path = "(use starknet::syscalls::library_call_syscall)"
+    completion_label_type_info = "fn(class_hash: ClassHash, function_selector: felt252, calldata: Span<felt252>) -> Result<Span<felt252>, Array<felt252>> nopanic"
     insert_text = "library_call_syscall(${1:class_hash}, ${2:function_selector}, ${3:calldata})"
     text_edits = ["""
     use starknet::syscalls::library_call_syscall;
@@ -166,15 +172,16 @@ fn only_before_cursor() {
 
     [[completions]]
     completion_label = "blake"
-    completion_label_path = "core::blake"
+    completion_label_path = "(use core::blake)"
     text_edits = ["""
     use core::blake;
 
     """]
 
     [[completions]]
-    completion_label = "blake2s_compress"
-    completion_label_path = "core::blake::blake2s_compress"
+    completion_label = "blake2s_compress(...)"
+    completion_label_path = "(use core::blake::blake2s_compress)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_compress(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_compress;
@@ -182,8 +189,9 @@ fn only_before_cursor() {
     """]
 
     [[completions]]
-    completion_label = "blake2s_finalize"
-    completion_label_path = "core::blake::blake2s_finalize"
+    completion_label = "blake2s_finalize(...)"
+    completion_label_path = "(use core::blake::blake2s_finalize)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_finalize(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_finalize;
@@ -192,15 +200,16 @@ fn only_before_cursor() {
 
     [[completions]]
     completion_label = "byte_array"
-    completion_label_path = "core::byte_array"
+    completion_label_path = "(use core::byte_array)"
     text_edits = ["""
     use core::byte_array;
 
     """]
 
     [[completions]]
-    completion_label = "library_call_syscall"
-    completion_label_path = "starknet::syscalls::library_call_syscall"
+    completion_label = "library_call_syscall(...)"
+    completion_label_path = "(use starknet::syscalls::library_call_syscall)"
+    completion_label_type_info = "fn(class_hash: ClassHash, function_selector: felt252, calldata: Span<felt252>) -> Result<Span<felt252>, Array<felt252>> nopanic"
     insert_text = "library_call_syscall(${1:class_hash}, ${2:function_selector}, ${3:calldata})"
     text_edits = ["""
     use starknet::syscalls::library_call_syscall;
@@ -226,7 +235,7 @@ fn disallow_recursive_definition() {
 
     [[completions]]
     completion_label = "OverflowingAdd"
-    completion_label_path = "core::num::traits::OverflowingAdd"
+    completion_label_path = "(use core::num::traits::OverflowingAdd)"
     text_edits = ["""
     use core::num::traits::OverflowingAdd;
 
@@ -234,7 +243,7 @@ fn disallow_recursive_definition() {
 
     [[completions]]
     completion_label = "OverflowingMul"
-    completion_label_path = "core::num::traits::OverflowingMul"
+    completion_label_path = "(use core::num::traits::OverflowingMul)"
     text_edits = ["""
     use core::num::traits::OverflowingMul;
 
@@ -242,7 +251,7 @@ fn disallow_recursive_definition() {
 
     [[completions]]
     completion_label = "OverflowingSub"
-    completion_label_path = "core::num::traits::OverflowingSub"
+    completion_label_path = "(use core::num::traits::OverflowingSub)"
     text_edits = ["""
     use core::num::traits::OverflowingSub;
 
@@ -291,8 +300,9 @@ fn work_with_params() {
     detail = "felt252"
 
     [[completions]]
-    completion_label = "a"
-    completion_label_path = "a"
+    completion_label = "a(...)"
+    completion_label_path = "(use a)"
+    completion_label_type_info = "fn(paxram: felt252, paxram2: felt252, paxram3: felt252) -> ()"
     insert_text = "a(${1:paxram}, ${2:paxram2}, ${3:paxram3})"
 
     [[completions]]
@@ -300,13 +310,15 @@ fn work_with_params() {
     insert_text = 'panic!("$1")'
 
     [[completions]]
-    completion_label = "panic"
-    completion_label_path = "panic"
+    completion_label = "panic(...)"
+    completion_label_path = "(use panic)"
+    completion_label_type_info = "fn(data: Array<felt252>) -> crate::never"
     insert_text = "panic(${1:data})"
 
     [[completions]]
-    completion_label = "max"
-    completion_label_path = "core::cmp::max"
+    completion_label = "max(...)"
+    completion_label_path = "(use core::cmp::max)"
+    completion_label_type_info = "fn(a: T, b: T) -> T"
     insert_text = "max(${1:a}, ${2:b})"
     text_edits = ["""
     use core::cmp::max;
@@ -337,15 +349,16 @@ fn mixed_params_vars() {
 
     [[completions]]
     completion_label = "blake"
-    completion_label_path = "core::blake"
+    completion_label_path = "(use core::blake)"
     text_edits = ["""
     use core::blake;
 
     """]
 
     [[completions]]
-    completion_label = "blake2s_compress"
-    completion_label_path = "core::blake::blake2s_compress"
+    completion_label = "blake2s_compress(...)"
+    completion_label_path = "(use core::blake::blake2s_compress)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_compress(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_compress;
@@ -353,8 +366,9 @@ fn mixed_params_vars() {
     """]
 
     [[completions]]
-    completion_label = "blake2s_finalize"
-    completion_label_path = "core::blake::blake2s_finalize"
+    completion_label = "blake2s_finalize(...)"
+    completion_label_path = "(use core::blake::blake2s_finalize)"
+    completion_label_type_info = "fn(state: Box<[u32; 8]>, byte_count: u32, msg: Box<[u32; 16]>) -> Box<[u32; 8]> nopanic"
     insert_text = "blake2s_finalize(${1:state}, ${2:byte_count}, ${3:msg})"
     text_edits = ["""
     use core::blake::blake2s_finalize;
@@ -363,15 +377,16 @@ fn mixed_params_vars() {
 
     [[completions]]
     completion_label = "byte_array"
-    completion_label_path = "core::byte_array"
+    completion_label_path = "(use core::byte_array)"
     text_edits = ["""
     use core::byte_array;
 
     """]
 
     [[completions]]
-    completion_label = "library_call_syscall"
-    completion_label_path = "starknet::syscalls::library_call_syscall"
+    completion_label = "library_call_syscall(...)"
+    completion_label_path = "(use starknet::syscalls::library_call_syscall)"
+    completion_label_type_info = "fn(class_hash: ClassHash, function_selector: felt252, calldata: Span<felt252>) -> Result<Span<felt252>, Array<felt252>> nopanic"
     insert_text = "library_call_syscall(${1:class_hash}, ${2:function_selector}, ${3:calldata})"
     text_edits = ["""
     use starknet::syscalls::library_call_syscall;


### PR DESCRIPTION
Consolidate logic for generating snippets for functions and structs.
Also aligns the completions to look the same as RAs' ones.

To do in next PRs: Aligning rest of completions (for non-importable completions) to have proper type hinting (now it's broken). [This issue namely](https://github.com/software-mansion/cairols/issues/1129)

Closes #1080 