### PR TITLE
Use new compiler APIs for doc link parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,6 @@ dependencies = [
  "memchr",
  "mimalloc",
  "pathdiff",
- "pulldown-cmark",
  "regex",
  "salsa",
  "scarb-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ lsp-server = "0.7.8"
 lsp-types = "=0.95.1"
 memchr = "2.7.6"
 mimalloc = "0.1.48"
-pulldown-cmark = "0.13.0"
 salsa = "0.26.0"
 scarb-metadata = "1.15.1"
 scarb-proc-macro-server-types = "0.5.0"
@@ -101,7 +100,7 @@ similar = "2.7"
 # This ensures no duplicate instances of Cairo crates are pulled in by mistake.
 [patch.crates-io]
 cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "bf4bb15a41094a08b06c7b1c502ffaa47d49aa8a" }
-cairo-language-common = { git = "https://github.com/software-mansion/cairo-language-common" , rev = "e780ac2be99edda452643a8edb4b10acc7adccf1" }
+cairo-language-common = { git = "https://github.com/software-mansion/cairo-language-common", rev = "e780ac2be99edda452643a8edb4b10acc7adccf1" }
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "bf4bb15a41094a08b06c7b1c502ffaa47d49aa8a" }
 cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "bf4bb15a41094a08b06c7b1c502ffaa47d49aa8a" }
 cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", rev = "bf4bb15a41094a08b06c7b1c502ffaa47d49aa8a" }

--- a/src/ide/markdown.rs
+++ b/src/ide/markdown.rs
@@ -2,10 +2,6 @@
 //!
 //! Markdown is used because this is the format used by the LSP protocol for rich text.
 
-use std::ops::Range;
-
-use pulldown_cmark::{BrokenLink, Event, LinkType, Options, Parser as MarkdownParser, Tag, TagEnd};
-
 /// Horizontal rule.
 pub const RULE: &str = "---\n";
 /// or //! - both have 3 characters we often want to skip.
@@ -17,65 +13,4 @@ pub fn fenced_code_block(code: &str) -> String {
         return String::new();
     }
     format!("```cairo\n{code}\n```\n")
-}
-
-pub struct DocLink {
-    /// Byte offsets into the original markdown content (not the link label text).
-    /// Example: in "See [`crate::Foo`]" the range covers the full "[`crate::Foo`]" span.
-    pub range: Range<usize>,
-    /// Byte offsets into the original markdown content for the link label itself.
-    /// Example: in "See [`crate::Foo`]" the label range covers "crate::Foo".
-    pub label_range: Range<usize>,
-    /// Only the first label chunk is captured; mixed code/text labels are ignored.
-    pub label_text: String,
-}
-
-pub fn parse_doc_links(content: &str) -> Vec<DocLink> {
-    let mut options = Options::empty();
-    options.insert(Options::ENABLE_TABLES);
-    // Force unresolved reference links to emit `Link` events so we can still parse their ranges.
-    let mut replacer = |broken_link: BrokenLink<'_>| {
-        if matches!(broken_link.link_type, LinkType::ShortcutUnknown | LinkType::Shortcut) {
-            return Some((broken_link.reference.to_string().into(), "".into()));
-        }
-        None
-    };
-    let parser =
-        MarkdownParser::new_with_broken_link_callback(content, options, Some(&mut replacer));
-
-    let mut results = Vec::new();
-    let mut link_start: Option<usize> = None;
-    let mut label_range: Option<Range<usize>> = None;
-    let mut label_text: Option<String> = None;
-    let mut in_link = false;
-
-    for (event, range) in parser.into_offset_iter() {
-        match event {
-            Event::Start(Tag::Link { .. }) => {
-                link_start = Some(range.start);
-                label_range = None;
-                label_text = None;
-                in_link = true;
-            }
-            Event::End(TagEnd::Link) => {
-                if let Some(start) = link_start.take() {
-                    let label_range = label_range.take().unwrap_or(start..start);
-                    let label_text = label_text.take().unwrap_or_default();
-                    results.push(DocLink { range: start..range.end, label_range, label_text });
-                }
-                in_link = false;
-            }
-            Event::Text(text) if in_link && label_range.is_none() => {
-                label_range = Some(range.start..range.end);
-                label_text = Some(text.to_string());
-            }
-            Event::Code(text) if in_link && label_range.is_none() => {
-                label_range = Some(range.start..range.end);
-                label_text = Some(text.to_string());
-            }
-            _ => {}
-        }
-    }
-
-    results
 }

--- a/src/ide/navigation/goto_definition.rs
+++ b/src/ide/navigation/goto_definition.rs
@@ -1,6 +1,7 @@
 use std::ops::Not;
 
 use cairo_lang_defs::db::DefsGroup;
+use cairo_lang_doc::db::DocGroup;
 use cairo_lang_filesystem::ids::{
     FileId, FileKind, FileLongId, SmolStrId, SpanInFile, VirtualFile,
 };
@@ -11,14 +12,12 @@ use cairo_lang_semantic::expr::inference::InferenceId;
 use cairo_lang_semantic::lsp_helpers::LspHelpers;
 use cairo_lang_semantic::resolve::{ResolutionContext, Resolver};
 use cairo_lang_syntax::node::ast::{PathSegment, TerminalIdentifier};
-use cairo_lang_syntax::node::kind::SyntaxKind;
 use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
 use cairo_lang_utils::Intern;
 use cairo_lang_utils::ordered_hash_set::OrderedHashSet;
 use cairo_language_common::CommonGroup;
 use lsp_types::{GotoDefinitionParams, GotoDefinitionResponse, Location};
 
-use crate::ide::markdown::{COMMENT_TOKEN_PREFIX_LEN, parse_doc_links};
 use crate::lang::db::{AnalysisDatabase, LsSyntaxGroup};
 use crate::lang::defs::{NonMacroModuleId, ResolvedItem, SymbolDef, SymbolSearch};
 use crate::lang::lsp::{LsProtoGroup, ToCairo};
@@ -55,45 +54,25 @@ fn try_goto_doc_link_def(
 ) -> Option<Location> {
     let cursor_offset = position.offset_in_file(db, file)?;
     let doc_token = db.find_syntax_node_at_position(file, position)?;
-    if !matches!(
-        doc_token.kind(db),
-        SyntaxKind::TokenSingleLineDocComment | SyntaxKind::TokenSingleLineInnerComment,
-    ) {
-        return None;
-    };
     let doc_token_span = doc_token.span_without_trivia(db);
     if !doc_token_span.contains(TextSpan::cursor(cursor_offset)) {
         return None;
     }
 
-    // Get the doc-comment content and parse the links it contains
-    let doc_token_text = doc_token.text(db)?.to_string(db);
-    let content = &doc_token_text[COMMENT_TOKEN_PREFIX_LEN..];
-    let links = parse_doc_links(content);
+    // Get the doc-comment links using compiler-provided spans.
+    let links = db.get_embedded_markdown_links(doc_token);
+    let cursor_span = TextSpan::cursor(cursor_offset);
+    let link = links.into_iter().find(|link| link.link_span.contains(cursor_span))?;
 
-    // Convert absolute cursor offset (in file) to an offset relative to the doc-comment (excluding leading /// or //!).
-    let doc_relative_cursor_offset = (cursor_offset - doc_token_span.start).as_u32() as usize;
-    if doc_relative_cursor_offset < COMMENT_TOKEN_PREFIX_LEN {
-        return None; // We can't have a link before the leading `///` or `//!`
-    }
-    let doc_relative_cursor_offset = doc_relative_cursor_offset - COMMENT_TOKEN_PREFIX_LEN;
+    let dest_text = link.dest_text?.to_string();
 
-    let link =
-        links.into_iter().find(|link| link.label_range.contains(&doc_relative_cursor_offset))?;
-
-    // Offset of the label relative to the link label start
-    let label_relative_cursor_offset =
-        doc_relative_cursor_offset.checked_sub(link.label_range.start)?;
-
-    let expr_path = parse_doc_link_path(db, link.label_text.as_str())?;
+    let expr_path = parse_doc_link_path(db, dest_text.as_str())?;
 
     // We want to resolve the path up to the segment containing the cursor
-    let segments = doc_link_segments_for_offset(
-        db,
-        &expr_path,
-        link.label_text.as_str(),
-        label_relative_cursor_offset,
-    )?;
+    // Default to the whole path.
+    let segments =
+        doc_link_segments_for_offset(db, &expr_path, &dest_text, link.dest_span?, cursor_offset)
+            .unwrap_or_else(|| expr_path.segments(db).elements_vec(db));
 
     // Run resolver to retrieve the definition node.
     let module_id = db.find_module_containing_node(doc_token)?;
@@ -115,46 +94,55 @@ fn try_goto_doc_link_def(
 // This is needed because we can't parse doc comments directly.
 fn parse_doc_link_path<'db>(
     db: &'db AnalysisDatabase,
-    link_text: &str,
+    dest_text: &str,
 ) -> Option<ast::ExprPath<'db>> {
     let virtual_file = FileLongId::Virtual(VirtualFile {
         parent: None,
         name: SmolStrId::from(db, "doc-link"),
-        content: SmolStrId::from(db, link_text),
+        content: SmolStrId::from(db, dest_text),
         code_mappings: Default::default(),
         kind: FileKind::Expr,
         original_item_removed: false,
     })
     .intern(db);
 
-    let expr = db.file_expr_syntax(virtual_file).ok()?;
+    let expr = match db.file_expr_syntax(virtual_file) {
+        Ok(expr) => expr,
+        Err(_) => return None,
+    };
     let ast::Expr::Path(expr_path) = expr else {
         return None;
     };
-
     Some(expr_path)
 }
 
 // Returns path segments up to the one containing `cursor_offset`, or the last segment before it.
 fn doc_link_segments_for_offset<'db>(
     db: &'db AnalysisDatabase,
-    expr_path: &ast::ExprPath<'db>,
-    link_text: &str,
-    cursor_offset: usize,
+    dest_expr_path: &ast::ExprPath<'db>,
+    dest_text: &str,
+    dest_span: TextSpan,
+    cursor_offset: TextOffset,
 ) -> Option<Vec<PathSegment<'db>>> {
-    if link_text.as_bytes().get(cursor_offset) == Some(&b':') {
+    let absolute_cursor = TextSpan::cursor(cursor_offset);
+    if !dest_span.contains(absolute_cursor) {
+        return None;
+    }
+    let relative_cursor_offset = (cursor_offset - dest_span.start).as_u32();
+    if dest_text.as_bytes().get(relative_cursor_offset as usize) == Some(&b':') {
         return None;
     }
 
-    let cursor = TextOffset::START.add_width(TextWidth::at(link_text, cursor_offset));
-    let cursor_span = TextSpan::cursor(cursor);
-    let segments = expr_path.segments(db).elements_vec(db);
+    let relative_cursor =
+        TextOffset::START.add_width(TextWidth::new_for_testing(relative_cursor_offset));
+    let relative_cursor_span = TextSpan::cursor(relative_cursor);
+    let segments = dest_expr_path.segments(db).elements_vec(db);
 
     let mut left_hand_segments = Vec::new();
     for segment in segments.into_iter() {
-        let span = segment.as_syntax_node().span_without_trivia(db);
+        let span = segment.as_syntax_node().span(db);
         left_hand_segments.push(segment);
-        if span.contains(cursor_span) {
+        if span.contains(relative_cursor_span) {
             break;
         }
     }

--- a/tests/e2e/goto_definition/doc_links.rs
+++ b/tests/e2e/goto_definition/doc_links.rs
@@ -20,19 +20,6 @@ fn crate_path_in_doc_link() {
 }
 
 #[test]
-fn doc_link_with_leading_whitespace() {
-    test_transform_plain!(GotoDefinition, r"
-    /// See [`  crate::Structu<caret>re`].
-    fn foo() {}
-    struct Structure {}
-    ", @r"
-    /// See [`  crate::Structure`].
-    fn foo() {}
-    struct <sel>Structure</sel> {}
-    ")
-}
-
-#[test]
 fn super_path_in_doc_link() {
     test_transform_plain!(GotoDefinition, r"
     mod parent {
@@ -111,7 +98,8 @@ fn doc_link_cursor_outside_label() {
     /// See [<caret>`crate::Struct`].
     struct Struct {}
     ", @r"
-    none response
+    /// See [`crate::Struct`].
+    struct <sel>Struct</sel> {}
     ")
 }
 
@@ -123,5 +111,16 @@ fn doc_link_to_corelib() {
     ", @r"
     // → core/src/option.cairo
     pub enum <sel>Option</sel><T> {
+    ")
+}
+
+#[test]
+fn doc_link_inline_with_path() {
+    test_transform_plain!(GotoDefinition, r"
+    /// See [Strukture](crate::Stru<caret>ct).
+    struct Struct {}
+    ", @r"
+    /// See [Strukture](crate::Struct).
+    struct <sel>Struct</sel> {}
     ")
 }


### PR DESCRIPTION
Related Cairo PR: https://github.com/starkware-libs/cairo/pull/9540 (adds the query we use here, consolidates API)