### PR TITLE
Collect Scarb manifest diagnostics from metadata output

### DIFF
--- a/src/lang/diagnostics/file_batches.rs
+++ b/src/lang/diagnostics/file_batches.rs
@@ -8,7 +8,6 @@ use lsp_types::Url;
 
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::lsp::LsProtoGroup;
-use crate::toolchain::scarb::SCARB_TOML;
 
 /// Finds all analyzable on disk files in `db` that are open and need to be analysed ASAP,
 /// thus _primary_.
@@ -20,15 +19,11 @@ pub fn find_primary_files<'db>(
     open_files
         .iter()
         .filter_map(|uri| db.file_for_url(uri))
-        // We only want to process on disk files.
-        // Relevant virtual files will be processed as a result of processing on disk files.
+        // 1. Filter out files that don't belong to any crate, e.g. removed modules.
+        // 2. We only want to process on disk files.
+        //    Relevant virtual files will be processed as a result of processing on disk files.
         .filter(|file_id| {
-            let FileLongId::OnDisk(path) = file_id.long(db) else { return false };
-
-            // 1. Process Cairo source files that belong to any crate, excluding removed modules.
-            // 2. Process open Scarb manifests through the dedicated Scarb manifest diagnostics path.
-            db.file_modules(*file_id).is_ok()
-                || path.file_name().and_then(|name| name.to_str()) == Some(SCARB_TOML)
+            db.file_modules(*file_id).is_ok() && matches!(file_id.long(db), FileLongId::OnDisk(_))
         })
         .collect()
 }

--- a/src/lang/diagnostics/mod.rs
+++ b/src/lang/diagnostics/mod.rs
@@ -22,6 +22,8 @@ use crate::server::trigger;
 use crate::state::{State, StateSnapshot};
 use crate::toolchain::scarb::ScarbToolchain;
 
+pub(crate) use self::scarb_manifest::collect_scarb_manifest_diagnostics_from_metadata_error;
+
 mod file_batches;
 mod file_diagnostics;
 mod lsp;

--- a/src/lang/diagnostics/refresh.rs
+++ b/src/lang/diagnostics/refresh.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use cairo_lang_filesystem::db::{FilesGroup, ext_as_virtual};
@@ -10,11 +10,10 @@ use crate::config::Config;
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::diagnostics::file_diagnostics::FilesDiagnostics;
 use crate::lang::diagnostics::project_diagnostics::ProjectDiagnostics;
-use crate::lang::diagnostics::scarb_manifest::collect_scarb_manifest_diagnostics;
 use crate::lang::lsp::LsProtoGroup;
 use crate::project::ConfigsRegistry;
 use crate::server::client::Notifier;
-use crate::toolchain::scarb::{SCARB_TOML, ScarbToolchain};
+use crate::toolchain::scarb::ScarbToolchain;
 
 /// Refresh diagnostics and send diffs to the client.
 #[tracing::instrument(skip_all)]
@@ -28,25 +27,15 @@ pub fn refresh_diagnostics<'db>(
     scarb_toolchain: ScarbToolchain,
 ) {
     for file in batch {
-        if is_scarb_manifest(db, file) {
-            refresh_scarb_manifest_diagnostics(
-                db,
-                file,
-                &project_diagnostics,
-                &notifier,
-                &scarb_toolchain,
-            );
-        } else {
-            refresh_file_diagnostics(
-                db,
-                config,
-                config_registry,
-                file,
-                &project_diagnostics,
-                &notifier,
-                &scarb_toolchain,
-            );
-        }
+        refresh_file_diagnostics(
+            db,
+            config,
+            config_registry,
+            file,
+            &project_diagnostics,
+            &notifier,
+            &scarb_toolchain,
+        );
     }
 }
 
@@ -108,42 +97,6 @@ fn refresh_file_diagnostics<'db>(
             version: None,
         });
     }
-}
-
-fn refresh_scarb_manifest_diagnostics<'db>(
-    db: &'db AnalysisDatabase,
-    manifest_file: FileId<'db>,
-    project_diagnostics: &ProjectDiagnostics,
-    notifier: &Notifier,
-    scarb_toolchain: &ScarbToolchain,
-) {
-    // Scarb manifest diagnostics are intentionally based on saved files only.
-    // Skip updates while this manifest has unsaved in-memory changes.
-    if db.file_overrides().contains_key(&manifest_file) {
-        return;
-    }
-
-    let Some(scarb) = scarb_toolchain.discover() else {
-        tracing::error!("could not find scarb executable");
-        return;
-    };
-    let Some(new_diags) = collect_scarb_manifest_diagnostics(db, manifest_file, scarb) else {
-        return;
-    };
-
-    for (url, diags) in new_diags {
-        project_diagnostics.update(url.clone(), HashMap::from([(url.clone(), diags.clone())]));
-        notifier.notify::<PublishDiagnostics>(PublishDiagnosticsParams {
-            uri: url,
-            diagnostics: diags,
-            version: None,
-        });
-    }
-}
-
-fn is_scarb_manifest<'db>(db: &'db AnalysisDatabase, file: FileId<'db>) -> bool {
-    let FileLongId::OnDisk(path) = file.long(db) else { return false };
-    path.file_name().and_then(|name| name.to_str()) == Some(SCARB_TOML)
 }
 
 /// For an on disk file - returns a path to it.

--- a/src/lang/diagnostics/scarb_manifest.rs
+++ b/src/lang/diagnostics/scarb_manifest.rs
@@ -1,16 +1,22 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
 use cairo_lang_filesystem::ids::FileId;
 use lsp_types::{Diagnostic, DiagnosticSeverity, Range, Url};
-use scarb_metadata::{Metadata, MetadataCommand, MetadataCommandError};
+#[cfg(test)]
+use scarb_metadata::{Metadata, MetadataCommand};
+use scarb_metadata::MetadataCommandError;
 use serde::Deserialize;
 use serde_json::Value;
 
+#[cfg(test)]
 use crate::lang::db::AnalysisDatabase;
+#[cfg(test)]
 use crate::lang::lsp::LsProtoGroup;
 
 /// Collects diagnostics for a `Scarb.toml` file.
+#[cfg(test)]
 pub fn collect_scarb_manifest_diagnostics<'db>(
     db: &'db AnalysisDatabase,
     manifest_file: FileId<'db>,
@@ -27,7 +33,7 @@ pub fn collect_scarb_manifest_diagnostics<'db>(
     }
 
     let diagnostics =
-        diagnostics_from_metadata_error(metadata_result.unwrap_err(), root_manifest_path);
+        diagnostics_from_metadata_error(&metadata_result.unwrap_err(), root_manifest_path);
     if diagnostics.is_empty() {
         return Some(diagnostics_by_file);
     }
@@ -42,6 +48,27 @@ pub fn collect_scarb_manifest_diagnostics<'db>(
     Some(diagnostics_by_file)
 }
 
+pub fn collect_scarb_manifest_diagnostics_from_metadata_error(
+    root_manifest_path: &Path,
+    error: &MetadataCommandError,
+) -> HashMap<Url, Vec<Diagnostic>> {
+    let root_url = Url::from_file_path(root_manifest_path).unwrap();
+    let diagnostics = diagnostics_from_metadata_error(error, root_manifest_path);
+    if diagnostics.is_empty() {
+        return HashMap::from([(root_url, Vec::new())]);
+    }
+
+    let mut diagnostics_by_file = HashMap::from([(root_url, Vec::new())]);
+    for diagnostic in diagnostics {
+        let entry = diagnostics_by_file.entry(diagnostic.uri).or_default();
+        if !entry.contains(&diagnostic.diagnostic) {
+            entry.push(diagnostic.diagnostic);
+        }
+    }
+    diagnostics_by_file
+}
+
+#[cfg(test)]
 fn run_metadata_validation(
     manifest_path: &Path,
     scarb_path: &Path,
@@ -57,24 +84,22 @@ struct LspScarbDiagnostic {
 }
 
 fn diagnostics_from_metadata_error(
-    error: MetadataCommandError,
+    error: &MetadataCommandError,
     root_manifest_path: &Path,
 ) -> Vec<LspScarbDiagnostic> {
     match error {
         MetadataCommandError::ScarbError { stdout, .. } => {
-            let diagnostics = extract_manifest_diagnostics_from_ndjson(&stdout);
+            let diagnostics = extract_manifest_diagnostics_from_ndjson(stdout);
             if !diagnostics.is_empty() {
                 return diagnostics;
             }
 
             // Fallback to an error message (should always be present) if no manifest diagnostics found.
-            first_ndjson_error_message(&stdout)
+            first_ndjson_error_message(stdout)
                 .map(|message| vec![build_diagnostic(root_manifest_path, message)])
                 .unwrap_or_default()
         }
-        MetadataCommandError::NotFound { stdout } => {
-            vec![build_diagnostic(root_manifest_path, stdout)]
-        }
+        MetadataCommandError::NotFound { stdout } => vec![build_diagnostic(root_manifest_path, stdout.to_string())],
         other => vec![build_diagnostic(root_manifest_path, other.to_string())],
     }
 }
@@ -325,10 +350,9 @@ mod tests {
             {"type":"error","message":"generic failure"}
         "#};
 
-        let diagnostics = diagnostics_from_metadata_error(
-            MetadataCommandError::ScarbError { stdout: stdout.to_string(), stderr: String::new() },
-            &root_path,
-        );
+        let error =
+            MetadataCommandError::ScarbError { stdout: stdout.to_string(), stderr: String::new() };
+        let diagnostics = diagnostics_from_metadata_error(&error, &root_path);
 
         let messages: Vec<_> =
             diagnostics.iter().map(|diag| diag.diagnostic.message.as_str()).collect();
@@ -340,10 +364,9 @@ mod tests {
         let root_path = PathBuf::from("/tmp/Scarb.toml");
         let stdout = r#"{"type":"error","message":"fallback error"}"#;
 
-        let diagnostics = diagnostics_from_metadata_error(
-            MetadataCommandError::ScarbError { stdout: stdout.to_string(), stderr: String::new() },
-            &root_path,
-        );
+        let error =
+            MetadataCommandError::ScarbError { stdout: stdout.to_string(), stderr: String::new() };
+        let diagnostics = diagnostics_from_metadata_error(&error, &root_path);
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].diagnostic.message, "fallback error");

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,4 +1,5 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::iter;
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -11,10 +12,8 @@ use cairo_lang_project::ProjectConfig;
 use crossbeam::channel::{Receiver, Sender};
 use lsp_types::notification::PublishDiagnostics;
 use lsp_types::notification::ShowMessage;
-use lsp_types::{
-    Diagnostic, DiagnosticSeverity, MessageType, Position, PublishDiagnosticsParams, Range,
-    ShowMessageParams, Url,
-};
+use lsp_types::{Diagnostic, MessageType, PublishDiagnosticsParams, ShowMessageParams, Url};
+use scarb_metadata::MetadataCommandError;
 use tracing::{debug, error, warn};
 
 pub use self::crate_data::{Crate, extract_custom_file_stems};
@@ -22,6 +21,7 @@ pub use self::model::ConfigsRegistry;
 pub use self::project_manifest_path::*;
 use crate::ide::code_lens::FileChange;
 use crate::lang::db::AnalysisDatabase;
+use crate::lang::diagnostics::collect_scarb_manifest_diagnostics_from_metadata_error;
 use crate::lang::proc_macros::controller::ProcMacroClientController;
 use crate::lsp::ext::CorelibVersionMismatch;
 use crate::project::crate_data::CrateInfo;
@@ -33,9 +33,7 @@ use crate::server::is_cairo_file_path;
 use crate::server::schedule::thread;
 use crate::server::schedule::thread::{JoinHandle, ThreadPriority};
 use crate::state::{Snapshot, State};
-use crate::toolchain::scarb::{
-    ScarbMetadataDiagnostic, ScarbMetadataDiagnosticSeverity, ScarbToolchain,
-};
+use crate::toolchain::scarb::ScarbToolchain;
 
 pub mod builtin_plugins;
 mod crate_data;
@@ -123,17 +121,15 @@ impl ProjectController {
                 crates,
                 workspace_dir,
                 workspace_manifest_path,
-                requested_manifest_path,
-                metadata_diagnostics,
             } => {
-                publish_scarb_metadata_diagnostics(
+                clear_scarb_manifest_diagnostics(
                     &notifier,
-                    &requested_manifest_path,
-                    metadata_diagnostics,
+                    crates
+                        .iter()
+                        .filter(|crate_info| crate_info.is_member)
+                        .map(|crate_info| crate_info.manifest_path.clone())
+                        .chain(iter::once(workspace_manifest_path.clone())),
                 );
-                if requested_manifest_path != workspace_manifest_path {
-                    clear_scarb_metadata_diagnostics(&notifier, &workspace_manifest_path);
-                }
 
                 debug!("updating crate roots from scarb metadata: {crates:#?}");
                 state.proc_macro_controller.request_defined_macros(db, workspace_manifest_path);
@@ -145,8 +141,12 @@ impl ProjectController {
                 );
                 state.analysis_progress_controller.project_model_loaded();
             }
-            ProjectUpdate::ScarbMetadataFailed { manifest_path, metadata_diagnostics } => {
-                publish_scarb_metadata_diagnostics(&notifier, &manifest_path, metadata_diagnostics);
+            ProjectUpdate::ScarbMetadataFailed { manifest_path, diagnostics_by_file } => {
+                publish_scarb_manifest_diagnostics(
+                    &notifier,
+                    &manifest_path,
+                    diagnostics_by_file,
+                );
 
                 // Try to set up a corelib at least if it is not in the db already.
                 try_to_init_unmanaged_core_if_not_present(
@@ -247,12 +247,10 @@ pub enum ProjectUpdate {
         crates: Vec<CrateInfo>,
         workspace_dir: PathBuf,
         workspace_manifest_path: PathBuf,
-        requested_manifest_path: PathBuf,
-        metadata_diagnostics: Vec<ScarbMetadataDiagnostic>,
     },
     ScarbMetadataFailed {
         manifest_path: PathBuf,
-        metadata_diagnostics: Vec<ScarbMetadataDiagnostic>,
+        diagnostics_by_file: HashMap<Url, Vec<Diagnostic>>,
     },
     CairoProjectToml(Box<Option<ProjectConfig>>),
     NoConfig(PathBuf),
@@ -311,30 +309,31 @@ impl ProjectControllerThread {
                     return None;
                 }
 
-                let (metadata, metadata_diagnostics) =
-                    self.scarb_toolchain.metadata_with_diagnostics(&manifest_path);
-                let metadata = metadata
-                    .with_context(|| {
-                        format!("failed to refresh scarb workspace: {}", manifest_path.display())
-                    })
-                    .inspect_err(|err| {
-                        error!("{err:?}");
-                    })
-                    .ok();
-
-                match metadata {
-                    Some(metadata) => ProjectUpdate::Scarb {
+                match self.scarb_toolchain.metadata(&manifest_path).with_context(|| {
+                    format!("failed to refresh scarb workspace: {}", manifest_path.display())
+                }) {
+                    Ok(metadata) => ProjectUpdate::Scarb {
                         crates: extract_crates(&metadata),
                         workspace_dir: metadata.workspace.root.into_std_path_buf(),
                         workspace_manifest_path: metadata
                             .workspace
                             .manifest_path
                             .into_std_path_buf(),
-                        requested_manifest_path: manifest_path,
-                        metadata_diagnostics,
                     },
-                    None => {
-                        ProjectUpdate::ScarbMetadataFailed { manifest_path, metadata_diagnostics }
+                    Err(err) => {
+                        error!("{err:?}");
+                        let diagnostics_by_file = err
+                            .chain()
+                            .find_map(|error| error.downcast_ref::<MetadataCommandError>())
+                            .map(|error| {
+                                collect_scarb_manifest_diagnostics_from_metadata_error(
+                                    &manifest_path,
+                                    error,
+                                )
+                            })
+                            .unwrap_or_default();
+
+                        ProjectUpdate::ScarbMetadataFailed { manifest_path, diagnostics_by_file }
                     }
                 }
             }
@@ -395,60 +394,35 @@ fn contains_core_from_scarb_cache(
         })
 }
 
-fn publish_scarb_metadata_diagnostics(
+fn publish_scarb_manifest_diagnostics(
     notifier: &Notifier,
     manifest_path: &PathBuf,
-    diagnostics: Vec<ScarbMetadataDiagnostic>,
+    diagnostics_by_file: HashMap<Url, Vec<Diagnostic>>,
 ) {
-    let Ok(uri) = Url::from_file_path(manifest_path) else { return };
-    let diagnostics = diagnostics.into_iter().map(scarb_metadata_diagnostic_to_lsp).collect();
+    if diagnostics_by_file.is_empty() {
+        clear_scarb_manifest_diagnostics(notifier, iter::once(manifest_path.clone()));
+        return;
+    }
 
-    notifier.notify::<PublishDiagnostics>(PublishDiagnosticsParams {
-        uri,
-        diagnostics,
-        version: None,
-    });
-}
-
-fn clear_scarb_metadata_diagnostics(notifier: &Notifier, manifest_path: &PathBuf) {
-    let Ok(uri) = Url::from_file_path(manifest_path) else { return };
-
-    notifier.notify::<PublishDiagnostics>(PublishDiagnosticsParams {
-        uri,
-        diagnostics: Vec::new(),
-        version: None,
-    });
-}
-
-fn scarb_metadata_diagnostic_to_lsp(diagnostic: ScarbMetadataDiagnostic) -> Diagnostic {
-    let severity = match diagnostic.severity {
-        ScarbMetadataDiagnosticSeverity::Error => DiagnosticSeverity::ERROR,
-        ScarbMetadataDiagnosticSeverity::Warning => DiagnosticSeverity::WARNING,
-    };
-
-    Diagnostic {
-        range: scarb_metadata_diagnostic_range(&diagnostic),
-        severity: Some(severity),
-        code: None,
-        code_description: None,
-        source: Some("scarb metadata".to_string()),
-        message: diagnostic.message,
-        related_information: None,
-        tags: None,
-        data: None,
+    for (uri, diagnostics) in diagnostics_by_file {
+        notifier.notify::<PublishDiagnostics>(PublishDiagnosticsParams {
+            uri,
+            diagnostics,
+            version: None,
+        });
     }
 }
 
-fn scarb_metadata_diagnostic_range(diagnostic: &ScarbMetadataDiagnostic) -> Range {
-    let (Some(line), Some(column)) = (diagnostic.line, diagnostic.column) else {
-        return Range::default();
-    };
-
-    let line = line.saturating_sub(1);
-    let start_character = column.saturating_sub(1);
-
-    Range {
-        start: Position { line, character: start_character },
-        end: Position { line, character: start_character.saturating_add(1) },
+fn clear_scarb_manifest_diagnostics(
+    notifier: &Notifier,
+    manifest_paths: impl IntoIterator<Item = PathBuf>,
+) {
+    for manifest_path in manifest_paths.into_iter().collect::<HashSet<_>>() {
+        let Ok(uri) = Url::from_file_path(manifest_path) else { continue };
+        notifier.notify::<PublishDiagnostics>(PublishDiagnosticsParams {
+            uri,
+            diagnostics: Vec::new(),
+            version: None,
+        });
     }
 }

--- a/src/server/routing/handlers.rs
+++ b/src/server/routing/handlers.rs
@@ -254,19 +254,6 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             }
         }
 
-        // Track changed Scarb manifests for diagnostics, even if they are not open in the editor.
-        // This ensures business-rule diagnostics are still published when filesystem events trigger
-        // project reloads and `scarb metadata` failures.
-        for change in &params.changes {
-            if is_scarb_manifest(&change.uri) {
-                if change.typ == FileChangeType::DELETED {
-                    state.open_files.remove(&change.uri);
-                } else {
-                    state.open_files.insert(change.uri.clone());
-                }
-            }
-        }
-
         // Reload workspace if a config file has changed.
         for change in &params.changes {
             let changed_file_path = change.uri.to_file_path().unwrap_or_default();

--- a/src/toolchain/scarb.rs
+++ b/src/toolchain/scarb.rs
@@ -3,12 +3,10 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Arc, OnceLock};
 
-use anyhow::{Context, Result, anyhow, bail, ensure};
+use anyhow::{Context, Result, bail, ensure};
 use lsp_types::notification::ShowMessage;
 use lsp_types::{MessageType, ShowMessageParams};
-use scarb_metadata::Metadata;
-use serde::Deserialize;
-use serde_json::Value;
+use scarb_metadata::{Metadata, MetadataCommand};
 use tracing::{debug, error, warn};
 use which::which;
 
@@ -17,20 +15,6 @@ use crate::lsp::ext::ScarbPathMissing;
 use crate::server::client::Notifier;
 
 pub const SCARB_TOML: &str = "Scarb.toml";
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ScarbMetadataDiagnostic {
-    pub severity: ScarbMetadataDiagnosticSeverity,
-    pub message: String,
-    pub line: Option<u32>,
-    pub column: Option<u32>,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum ScarbMetadataDiagnosticSeverity {
-    Error,
-    Warning,
-}
 
 /// The ultimate object for invoking Scarb.
 ///
@@ -149,34 +133,16 @@ impl ScarbToolchain {
     /// the progress of the operation or any actionable issues.
     #[tracing::instrument(skip(self))]
     pub fn metadata(&self, manifest: &Path) -> Result<Metadata> {
-        self.metadata_with_diagnostics(manifest).0
-    }
-
-    /// Calls `scarb metadata` for the given `Scarb.toml`, parses its output and
-    /// collects diagnostics emitted by Scarb itself.
-    #[tracing::instrument(skip(self))]
-    pub fn metadata_with_diagnostics(
-        &self,
-        manifest: &Path,
-    ) -> (Result<Metadata>, Vec<ScarbMetadataDiagnostic>) {
         let Some(scarb_path) = self.discover() else {
-            return (Err(anyhow!("could not find scarb executable")), Vec::new());
+            bail!("could not find scarb executable");
         };
 
-        let output = Command::new(scarb_path)
-            .arg("--json")
-            .arg("--manifest-path")
-            .arg(manifest)
-            .arg("metadata")
-            .arg("--format-version")
-            .arg("1")
-            .output()
+        let result = MetadataCommand::new()
+            .scarb_path(scarb_path)
+            .manifest_path(manifest)
+            .inherit_stderr()
+            .exec()
             .context("failed to execute: scarb metadata");
-
-        let (result, diagnostics) = match output {
-            Ok(output) => parse_metadata_command_output(manifest, output),
-            Err(err) => (Err(err), Vec::new()),
-        };
 
         if !self.is_silent && result.is_err() {
             self.notifier.notify::<ShowMessage>(ShowMessageParams {
@@ -187,7 +153,7 @@ impl ScarbToolchain {
             });
         }
 
-        (result, diagnostics)
+        result
     }
 
     pub fn proc_macro_server(&self, cwd: &Path) -> Result<Child> {
@@ -254,146 +220,5 @@ impl ScarbToolchain {
             })
             .inspect(|p| debug!("Scarb cache path: {}", p.display()))
             .inspect_err(|err| error!("{err:#?}"))
-    }
-}
-
-fn parse_metadata_command_output(
-    manifest: &Path,
-    output: std::process::Output,
-) -> (Result<Metadata>, Vec<ScarbMetadataDiagnostic>) {
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-    let mut metadata_json: Option<String> = None;
-    let mut diagnostics: Vec<ScarbMetadataDiagnostic> = Vec::new();
-
-    for line in stdout.lines().filter(|line| !line.trim().is_empty()) {
-        if let Some(diagnostic) = parse_scarb_diagnostic_event(line) {
-            diagnostics.push(diagnostic);
-            continue;
-        }
-
-        metadata_json = Some(line.to_string());
-    }
-
-    if output.status.success() {
-        let metadata = metadata_json
-            .ok_or_else(|| anyhow!("`scarb metadata` produced no metadata output"))
-            .and_then(|json| {
-                serde_json::from_str::<Metadata>(&json)
-                    .context("failed to parse `scarb metadata` output")
-            });
-        return (metadata, diagnostics);
-    }
-
-    if diagnostics.is_empty() {
-        diagnostics.push(ScarbMetadataDiagnostic {
-            severity: ScarbMetadataDiagnosticSeverity::Error,
-            message: non_empty_command_output(&stdout, &stderr).unwrap_or_else(|| {
-                "`scarb metadata` failed without additional details".to_string()
-            }),
-            line: None,
-            column: None,
-        });
-    }
-
-    let error_output = non_empty_command_output(&stdout, &stderr)
-        .unwrap_or_else(|| "`scarb metadata` failed without additional details".to_string());
-    let result = Err(anyhow!(
-        "failed to execute `scarb metadata` for {}: {}",
-        manifest.display(),
-        error_output
-    ));
-
-    (result, diagnostics)
-}
-
-fn non_empty_command_output(stdout: &str, stderr: &str) -> Option<String> {
-    let mut parts = Vec::new();
-    let trimmed_stdout = stdout.trim();
-    let trimmed_stderr = stderr.trim();
-
-    if !trimmed_stdout.is_empty() {
-        parts.push(trimmed_stdout);
-    }
-    if !trimmed_stderr.is_empty() {
-        parts.push(trimmed_stderr);
-    }
-
-    (!parts.is_empty()).then(|| parts.join("\n"))
-}
-
-#[derive(Deserialize)]
-struct ScarbDiagnosticEvent {
-    #[serde(rename = "type")]
-    typ: String,
-    message: String,
-}
-
-fn parse_scarb_diagnostic_event(line: &str) -> Option<ScarbMetadataDiagnostic> {
-    let value = serde_json::from_str::<Value>(line).ok()?;
-    value.get("type")?;
-    let event = serde_json::from_value::<ScarbDiagnosticEvent>(value).ok()?;
-
-    let severity = match event.typ.as_str() {
-        "error" => ScarbMetadataDiagnosticSeverity::Error,
-        "warning" => ScarbMetadataDiagnosticSeverity::Warning,
-        _ => return None,
-    };
-
-    let (line, column) = parse_line_and_column(&event.message);
-    Some(ScarbMetadataDiagnostic { severity, message: event.message, line, column })
-}
-
-fn parse_line_and_column(message: &str) -> (Option<u32>, Option<u32>) {
-    let marker = "at line ";
-    let Some(start) = message.find(marker) else {
-        return (None, None);
-    };
-
-    let remaining = &message[start + marker.len()..];
-    let Some((line, rest)) = remaining.split_once(", column ") else {
-        return (None, None);
-    };
-
-    let line = line.trim().parse::<u32>().ok();
-    let column =
-        rest.chars().take_while(|ch| ch.is_ascii_digit()).collect::<String>().parse::<u32>().ok();
-
-    (line, column)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        ScarbMetadataDiagnosticSeverity, parse_line_and_column, parse_scarb_diagnostic_event,
-    };
-
-    #[test]
-    fn parses_error_event_with_line_and_column() {
-        let line = r#"{"type":"error","message":"failed to parse manifest at: /tmp/Scarb.toml\n\nCaused by:\n    TOML parse error at line 2, column 8\n      |\n    2 | name = 1\n      |        ^\n    invalid type: integer `1`, expected a string"}"#;
-
-        let diagnostic = parse_scarb_diagnostic_event(line).unwrap();
-        assert_eq!(diagnostic.severity, ScarbMetadataDiagnosticSeverity::Error);
-        assert_eq!(diagnostic.line, Some(2));
-        assert_eq!(diagnostic.column, Some(8));
-    }
-
-    #[test]
-    fn parses_warning_event() {
-        let line = r#"{"type":"warning","message":"some warning"}"#;
-
-        let diagnostic = parse_scarb_diagnostic_event(line).unwrap();
-        assert_eq!(diagnostic.severity, ScarbMetadataDiagnosticSeverity::Warning);
-        assert_eq!(diagnostic.message, "some warning");
-    }
-
-    #[test]
-    fn extracts_line_and_column_only_when_pattern_exists() {
-        assert_eq!(
-            parse_line_and_column("TOML parse error at line 12, column 3"),
-            (Some(12), Some(3))
-        );
-        assert_eq!(parse_line_and_column("no position info"), (None, None));
     }
 }


### PR DESCRIPTION
## Summary
- collect Scarb manifest diagnostics implicitly from `scarb metadata` NDJSON output
- publish/clear manifest diagnostics via project update path instead of explicit Scarb.toml tracking in diagnostics collection status
- keep metadata success path unchanged for workspace loading while enriching failure reporting

## Validation
- cargo check -q
- cargo test -q toolchain::scarb::tests:: -- --nocapture