### PR TITLE
Schedule diags refresh on config reload

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ use crate::server::schedule::Task;
 /// Therefore, holding any references or copies of this struct or its values for
 /// longer periods of time should be avoided, unless the copy will be reactively updated on
 /// `workspace/didChangeConfiguration` requests.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     /// A user-provided path to the `core` crate source code for use in projects where `core` is
     /// unmanaged by the toolchain.
@@ -225,7 +225,7 @@ impl Config {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub enum TestRunner {
     #[default]
     Auto,

--- a/src/server/schedule/mod.rs
+++ b/src/server/schedule/mod.rs
@@ -12,6 +12,7 @@ use salsa::plumbing::current_revision;
 
 use self::task::BackgroundTaskBuilder;
 use self::thread::{JoinHandle, ThreadPriority};
+use crate::config::Config;
 use crate::server::client::{Client, Notifier, Requester, Responder};
 use crate::server::connection::ClientSender;
 use crate::server::schedule::task::BackgroundFnBuilder;
@@ -93,10 +94,14 @@ impl<'s> Scheduler<'s> {
                 let notifier = self.client.notifier();
                 let responder = self.client.responder();
                 let old_revision = current_revision(&self.state.db);
-                func(self.state, notifier.clone(), &mut self.client.requester, responder);
-                let new_revision = current_revision(&self.state.db);
+                let old_config: &Config = &self.state.config.snapshot();
 
-                if old_revision != new_revision {
+                func(self.state, notifier.clone(), &mut self.client.requester, responder);
+
+                let new_revision = current_revision(&self.state.db);
+                let new_config: &Config = &self.state.config.snapshot();
+
+                if old_revision != new_revision || old_config != new_config {
                     for hook in &self.sync_mut_task_hooks {
                         hook(self.state, self.meta_state.clone(), notifier.clone());
                     }


### PR DESCRIPTION
I can add a test if you really want to. My main motivation was that after I disable linter I have to make state mutation to make the lint diags disappear.