### PR TITLE
Support builtin macros type info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 [[package]]
 name = "cairo-language-common"
 version = "2.15.0"
-source = "git+https://github.com/software-mansion/cairo-language-common?rev=e780ac2be99edda452643a8edb4b10acc7adccf1#e780ac2be99edda452643a8edb4b10acc7adccf1"
+source = "git+https://github.com/software-mansion/cairo-language-common?rev=cdec07cd4dc5bdaf52096550d8d357a20a6cd037#cdec07cd4dc5bdaf52096550d8d357a20a6cd037"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ cairo-lang-syntax-codegen = { git = "https://github.com/starkware-libs/cairo", r
 cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "d534bf9e732eb82c170ab5a57de60e409298590a" }
 cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo", rev = "d534bf9e732eb82c170ab5a57de60e409298590a" }
 cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", rev = "d534bf9e732eb82c170ab5a57de60e409298590a" }
-cairo-language-common = { git = "https://github.com/software-mansion/cairo-language-common", rev = "e780ac2be99edda452643a8edb4b10acc7adccf1" }
+cairo-language-common = { git = "https://github.com/software-mansion/cairo-language-common", rev = "cdec07cd4dc5bdaf52096550d8d357a20a6cd037" }
 cairo-lint = { git = "https://github.com/software-mansion/cairo-lint", rev = "0a1da498777125b8f0d6291509c85f6502299da7" }
 # The profile used for CI in pull requests.
 # External dependencies are built with optimisation enabled,

--- a/tests/e2e/hover/type_info.rs
+++ b/tests/e2e/hover/type_info.rs
@@ -337,12 +337,12 @@ fn type_info_inside_attribute_macro() {
     "#)
 }
 
-/// Hover on an operator inside a built-in inline macro shows no type info — built-in macros use
-/// PatchBuilder::add_node which emits a single CodeOrigin::Start mapping per argument node rather
-/// than per-token mappings, so source tokens inside the token tree have no expression resultants
-/// to walk up from.
+/// Hover on an operator inside a built-in inline macro shows the type of the sub-expression.
+/// Built-in macros use PatchBuilder::add_node which now emits per-token CodeOrigin::Start
+/// mappings, so each source token inside the argument list has an expansion resultant and type
+/// resolution works via the standard expression-lookup path.
 #[test]
-fn no_type_info_inside_builtin_inline_macro() {
+fn type_info_inside_builtin_inline_macro() {
     test_transform_plain!(Hover, r#"
     fn main() {
         let _ = array![1_u32 <caret>+ 2_u32];
@@ -350,6 +350,14 @@ fn no_type_info_inside_builtin_inline_macro() {
     "#, @r#"
     source_context = """
         let _ = array![1_u32 <caret>+ 2_u32];
+    """
+    highlight = """
+        let _ = array![<sel>1_u32 + 2_u32</sel>];
+    """
+    popover = """
+    ```cairo
+    u32
+    ```
     """
     "#)
 }

--- a/tests/e2e/hover/variables.rs
+++ b/tests/e2e/hover/variables.rs
@@ -169,5 +169,13 @@ fn issue_80() {
     source_context = """
         format!("0x{}", str<caret>ing)
     """
+    highlight = """
+        format!("0x{}", <sel>string</sel>)
+    """
+    popover = """
+    ```cairo
+    let string: ByteArray
+    ```
+    """
     "#)
 }


### PR DESCRIPTION
Relies on https://github.com/software-mansion/cairo-language-common/pull/16
