### PR TITLE
Reload project model when integration test files are created

### DIFF
--- a/src/server/routing/handlers.rs
+++ b/src/server/routing/handlers.rs
@@ -6,6 +6,7 @@
 // +-----------------------------------------------------+
 
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
+use std::path::Path;
 
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::override_file_content;
@@ -254,7 +255,11 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             }
         }
 
-        // Reload workspace if a config file has changed.
+        // Reload workspace if a config file has changed or if the Scarb integration-test crate
+        // structure changed. Scarb derives integration-test crates from direct `tests/*.cairo`
+        // files when `tests/lib.cairo` is absent, so create/delete events can change metadata.
+        let mut should_reload_backend = false;
+        let mut should_restart_proc_macros = false;
         for change in &params.changes {
             let changed_file_path = change.uri.to_file_path().unwrap_or_default();
             let changed_file_name = changed_file_path.file_name().unwrap_or_default();
@@ -262,9 +267,18 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
             //  metadata call, so it is easy to fall in a loop here.
             if ["Scarb.toml", "cairo_project.toml"].map(Some).contains(&changed_file_name.to_str())
             {
-                trace!("reloading backend from didChangeWatchedFiles handler");
-                Backend::reload(state, requester)?;
+                should_reload_backend = true;
+                should_restart_proc_macros = true;
+            } else if is_integration_test_structure_change(&changed_file_path, change.typ) {
+                should_reload_backend = true;
+            }
+        }
 
+        if should_reload_backend {
+            trace!("reloading backend from didChangeWatchedFiles handler");
+            Backend::reload(state, requester)?;
+
+            if should_restart_proc_macros {
                 state
                     .proc_macro_controller
                     .force_restart_without_rate_limit(&mut state.db, &state.config);
@@ -284,6 +298,12 @@ impl SyncNotificationHandler for DidChangeWatchedFiles {
 
         Ok(())
     }
+}
+
+fn is_integration_test_structure_change(path: &Path, change_type: FileChangeType) -> bool {
+    matches!(change_type, FileChangeType::CREATED | FileChangeType::DELETED)
+        && path.extension().is_some_and(|extension| extension == "cairo")
+        && path.parent().and_then(Path::file_name).is_some_and(|parent| parent == "tests")
 }
 
 impl SyncNotificationHandler for DidCloseTextDocument {

--- a/tests/e2e/scarb/scarb_toml_change/integration_tests.rs
+++ b/tests/e2e/scarb/scarb_toml_change/integration_tests.rs
@@ -1,0 +1,48 @@
+use indoc::indoc;
+use lsp_types::notification::DidChangeWatchedFiles;
+use lsp_types::{DidChangeWatchedFilesParams, FileChangeType, FileEvent};
+
+use super::caps;
+use crate::support::normalize::normalize;
+use crate::support::sandbox;
+
+#[test]
+fn newly_created_integration_test_file_reloads_project_model() {
+    let mut ls = sandbox! {
+        files {
+            "Scarb.toml" => indoc! (r#"
+                [package]
+                name = "test_package"
+                version = "0.1.0"
+                edition = "2025_12"
+            "#),
+            "src/lib.cairo" => "",
+        }
+        client_capabilities = caps;
+    };
+
+    let analyzed_crates = ls.open_and_wait_for_project_update("src/lib.cairo");
+    let analyzed_crates = normalize(&ls, analyzed_crates);
+    assert!(!analyzed_crates.contains("[ROOT]/tests/new_test.cairo"), "{analyzed_crates}");
+
+    ls.edit_file(
+        "tests/new_test.cairo",
+        indoc! {r#"
+            #[test]
+            fn new_test() {}
+        "#},
+    );
+    ls.send_notification::<DidChangeWatchedFiles>(DidChangeWatchedFilesParams {
+        changes: vec![FileEvent {
+            uri: ls.doc_id("tests/new_test.cairo").uri,
+            typ: FileChangeType::CREATED,
+        }],
+    });
+
+    let analyzed_crates_after_test_creation = ls.wait_for_project_update();
+    let analyzed_crates_after_test_creation = normalize(&ls, analyzed_crates_after_test_creation);
+    assert!(
+        analyzed_crates_after_test_creation.contains("[ROOT]/tests/new_test.cairo"),
+        "{analyzed_crates_after_test_creation}"
+    );
+}

--- a/tests/e2e/scarb/scarb_toml_change/mod.rs
+++ b/tests/e2e/scarb/scarb_toml_change/mod.rs
@@ -2,6 +2,7 @@ use lsp_types::{
     ClientCapabilities, DidChangeWatchedFilesClientCapabilities, WorkspaceClientCapabilities,
 };
 
+mod integration_tests;
 mod invalid;
 mod removing_dependency;
 mod removing_member;


### PR DESCRIPTION
Fixes #1285.

Scarb can derive integration-test crates from direct `tests/*.cairo` files, so create/delete file events can change project metadata even when `Scarb.toml` is unchanged. Before this change, CairoLS invalidated the changed Cairo file but did not reload the project model, so newly created integration tests were not analyzed until a broader reload happened.

This keeps the reload intentionally narrow: only direct `tests/*.cairo` create/delete events trigger a project model reload. Regular Cairo file edits still avoid a backend reload, and proc-macro restart remains limited to config-file changes.

Verification:
- `cargo fmt --check`
- `SCARB_BIN="$(asdf where scarb nightly-2026-05-09)/bin" PATH="$SCARB_BIN:$PATH" cargo test scarb_toml_change`

Local note: these tests need the repo-pinned Scarb `nightly-2026-05-09`; an older `scarb 2.8.0` on PATH fails unrelated Scarb/corelib behavior.
