### PR TITLE
feat: add non-blocking try_wait on trigger receiver

### DIFF
--- a/src/server/trigger.rs
+++ b/src/server/trigger.rs
@@ -71,6 +71,12 @@ impl<T> Receiver<T> {
     pub fn wait(&self) -> Option<T> {
         self.0.wait()
     }
+
+    /// Attempts to read a buffered value without blocking.
+    #[allow(dead_code)]
+    pub fn try_wait(&self) -> Option<T> {
+        self.0.try_wait()
+    }
 }
 
 impl<T> Drop for Receiver<T> {
@@ -145,6 +151,24 @@ impl<T> Inner<T> {
                 State::Activated(value) => return Some(value),
                 State::Disconnected(value) => return value,
             }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn try_wait(&self) -> Option<T> {
+        let &Inner { state_mutex, .. } = &self;
+
+        let mut state_guard = state_mutex.lock().expect(POISON_PANIC);
+        let idle = match &*state_guard {
+            State::Pending => return None,
+            State::Activated(_) => State::Pending,
+            State::Disconnected(_) => State::Disconnected(None),
+        };
+
+        match mem::replace(&mut *state_guard, idle) {
+            State::Pending => None,
+            State::Activated(value) => Some(value),
+            State::Disconnected(value) => value,
         }
     }
 }

--- a/src/server/trigger_test.rs
+++ b/src/server/trigger_test.rs
@@ -51,3 +51,19 @@ fn test_drop_receiver() {
     // This line should just do nothing.
     sender.activate(42);
 }
+
+#[test]
+fn test_try_wait() {
+    let (sender, receiver) = trigger();
+
+    assert_eq!(receiver.try_wait(), None);
+
+    sender.activate(42);
+    assert_eq!(receiver.try_wait(), Some(42));
+    assert_eq!(receiver.try_wait(), None);
+
+    sender.activate(43);
+    drop(sender);
+    assert_eq!(receiver.try_wait(), Some(43));
+    assert_eq!(receiver.try_wait(), None);
+}


### PR DESCRIPTION
Adds `try_wait` / `Inner::try_wait` so the diagnostics controller can
drain queued triggers without blocking — needed for the debounce loop
that collapses rapid refresh requests into one scarb check invocation.