### PR TITLE
Add `replace` type quick fixes for invalid `inherits` in Scarb manifest

### DIFF
--- a/src/ide/code_actions/scarb_manifest/profile_inheritance_invalid.rs
+++ b/src/ide/code_actions/scarb_manifest/profile_inheritance_invalid.rs
@@ -1,7 +1,67 @@
 use lsp_types::CodeAction;
+use toml_edit::value;
 
-use super::{ManifestActionContext, remove_key_at_range_action};
+use super::toml::replace_key_path_value;
+use super::{ManifestActionContext, remove_key_at_range_action, replace_manifest_action};
+use crate::lang::lsp::ToCairo;
+
+/// Valid `inherits` profile values, see Scarb diagnostic `SE0004`.
+const VALID_PROFILES: [&str; 2] = ["dev", "release"];
 
 pub fn build(ctx: &ManifestActionContext<'_>) -> Vec<CodeAction> {
-    remove_key_at_range_action(ctx, "Remove invalid").into_iter().collect()
+    let Some(inherits_path) = inherits_path(ctx) else {
+        return Vec::new();
+    };
+
+    let mut actions = Vec::new();
+
+    if let Some(action) = remove_inherits_action(ctx) {
+        actions.push(action);
+    }
+
+    for profile in VALID_PROFILES {
+        if let Some(action) = set_inherits_to_action(ctx, &inherits_path, profile) {
+            actions.push(action);
+        }
+    }
+
+    actions
+}
+
+/// Relies on the fact that the diagnostic is pinned to `inherits` key directly
+fn inherits_path(ctx: &ManifestActionContext<'_>) -> Option<Vec<String>> {
+    let offset = ctx
+        .diagnostic
+        .range
+        .start
+        .to_cairo()
+        .offset_in_file(ctx.db, ctx.file_id)
+        .map(|offset| offset.as_u32() as usize)?;
+
+    super::find_key_path_at_offset(ctx.raw_toml, offset)
+}
+
+/// Generates the quick fix that removes the invalid `inherits` field.
+fn remove_inherits_action(ctx: &ManifestActionContext<'_>) -> Option<CodeAction> {
+    remove_key_at_range_action(ctx, "Remove invalid")
+}
+
+/// Generates the quick fix that rewrites `inherits` to a valid profile value.
+fn set_inherits_to_action(
+    ctx: &ManifestActionContext<'_>,
+    inherits_path: &[String],
+    profile: &str,
+) -> Option<CodeAction> {
+    let new_text = replace_key_path_value(
+        ctx.raw_toml,
+        inherits_path,
+        value(profile).into_value().expect("string literal should build a TOML value"),
+    )?;
+
+    Some(replace_manifest_action(
+        ctx,
+        new_text,
+        format!("Set `inherits` to `\"{profile}\"`"),
+        ctx.diagnostic.clone(),
+    ))
 }

--- a/tests/e2e/code_actions/scarb_manifest.rs
+++ b/tests/e2e/code_actions/scarb_manifest.rs
@@ -91,10 +91,12 @@ fn manifest_profile_inheritance_invalid_code_action_endpoint_returns_fixes() {
     let dev_action = find_code_action(code_actions.clone(), "Set `inherits` to `\"dev\"`");
     let dev_text = only_manifest_edit(&dev_action);
     assert!(dev_text.contains(r#"inherits = "dev""#), "{dev_text}");
+    assert!(!dev_text.contains(r#"inherits = "invalid""#), "{dev_text}");
 
     let release_action = find_code_action(code_actions, "Set `inherits` to `\"release\"`");
     let release_text = only_manifest_edit(&release_action);
     assert!(release_text.contains(r#"inherits = "release""#), "{release_text}");
+    assert!(!release_text.contains(r#"inherits = "invalid""#), "{release_text}");
 }
 
 #[test]

--- a/tests/e2e/code_actions/scarb_manifest.rs
+++ b/tests/e2e/code_actions/scarb_manifest.rs
@@ -64,23 +64,37 @@ fn manifest_inlining_strategy_conflict_code_action_endpoint_returns_fixes() {
 }
 
 #[test]
-fn manifest_profile_inheritance_invalid_code_action_endpoint_returns_fix() {
-    assert_manifest_quick_fix(
-        indoc! {r#"
-            [package]
-            name = "test_package"
-            version = "0.1.0"
-            edition = "2025_12"
+fn manifest_profile_inheritance_invalid_code_action_endpoint_returns_fixes() {
+    let manifest = indoc! {r#"
+        [package]
+        name = "test_package"
+        version = "0.1.0"
+        edition = "2025_12"
 
-            [profile.custom]
-            inherits = "invalid"
-        "#},
+        [profile.custom]
+        inherits = "invalid"
+    "#};
+
+    let diagnostic = manifest_diagnostic(
+        manifest,
         "profile can inherit from `dev` or `release` only, found `invalid`",
         "SE0004",
-        "Remove invalid `inherits` field",
-        r#"inherits = "invalid""#,
-        "[profile.custom]",
     );
+
+    let code_actions = manifest_code_actions(manifest, diagnostic);
+
+    let remove_action = find_code_action(code_actions.clone(), "Remove invalid `inherits` field");
+    let remove_text = only_manifest_edit(&remove_action);
+    assert!(!remove_text.contains("inherits"), "{remove_text}");
+    assert!(remove_text.contains("[profile.custom]"), "{remove_text}");
+
+    let dev_action = find_code_action(code_actions.clone(), "Set `inherits` to `\"dev\"`");
+    let dev_text = only_manifest_edit(&dev_action);
+    assert!(dev_text.contains(r#"inherits = "dev""#), "{dev_text}");
+
+    let release_action = find_code_action(code_actions, "Set `inherits` to `\"release\"`");
+    let release_text = only_manifest_edit(&release_action);
+    assert!(release_text.contains(r#"inherits = "release""#), "{release_text}");
 }
 
 #[test]


### PR DESCRIPTION
We have only a couple of supported inheritance values anyways so we can propose correct ones on user mistake