### PR TITLE
Emit more specific popup for metadata fail with cairo version mismatch

### DIFF
--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -21,7 +21,7 @@ pub use self::scarb_manifest_diagnostics::{
 };
 use self::scarb_manifest_diagnostics::{
     collect_scarb_manifest_diagnostics, manifest_diagnostics_from_ndjson,
-    scarb_metadata_messages_contain_only_errors,
+    scarb_metadata_failed_message,
 };
 use crate::ide::code_lens::FileChange;
 use crate::lang::db::AnalysisDatabase;
@@ -322,9 +322,13 @@ impl ProjectControllerThread {
                     .unwrap_or_else(|error| {
                         let metadata_messages = collect_scarb_manifest_diagnostics(error);
 
-                        if scarb_metadata_messages_contain_only_errors(&metadata_messages) {
-                            self.scarb_toolchain.notify_metadata_failed();
-                        }
+                        // A failed `scarb metadata` means the project could not be loaded, so we
+                        // always inform the user with a popup - the message is tailored to the
+                        // cause (e.g. a Cairo version mismatch) when we can recognize it.
+                        // Located manifest diagnostics are additionally surfaced inline.
+                        self.scarb_toolchain.notify_metadata_failed(scarb_metadata_failed_message(
+                            &metadata_messages,
+                        ));
 
                         ProjectUpdate::ScarbMetadataFailed {
                             manifest_path,

--- a/src/project/scarb_manifest_diagnostics.rs
+++ b/src/project/scarb_manifest_diagnostics.rs
@@ -9,6 +9,9 @@ use serde_json::Value;
 
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::lsp::Utf8Span;
+use crate::toolchain::scarb::{
+    SCARB_METADATA_CAIRO_VERSION_MISMATCH_MESSAGE, SCARB_METADATA_FAILED_MESSAGE,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScarbMetadataMessage {
@@ -33,9 +36,23 @@ fn diagnostics_to_display(all_messages: Vec<ScarbMetadataMessage>) -> Vec<ScarbM
     if !metadata_diagnostics.is_empty() { metadata_diagnostics } else { all_messages }
 }
 
-pub fn scarb_metadata_messages_contain_only_errors(messages: &[ScarbMetadataMessage]) -> bool {
-    !messages.is_empty()
-        && messages.iter().all(|message| matches!(message, ScarbMetadataMessage::MetadataError(_)))
+/// Picks the most specific user-facing message for a failed `scarb metadata` invocation.
+///
+/// When the failure is caused by a Cairo version requirement mismatch, returns a dedicated
+/// message pointing the user at the root cause instead of the generic one.
+pub fn scarb_metadata_failed_message(messages: &[ScarbMetadataMessage]) -> &'static str {
+    if messages.iter().any(scarb_metadata_message_is_cairo_version_mismatch) {
+        SCARB_METADATA_CAIRO_VERSION_MISMATCH_MESSAGE
+    } else {
+        SCARB_METADATA_FAILED_MESSAGE
+    }
+}
+
+fn scarb_metadata_message_is_cairo_version_mismatch(message: &ScarbMetadataMessage) -> bool {
+    match message {
+        ScarbMetadataMessage::MetadataError(message) => message.contains("required Cairo version"),
+        ScarbMetadataMessage::MetadataDiagnostic { .. } => false,
+    }
 }
 
 pub fn scarb_metadata_messages_to_diagnostics(
@@ -271,6 +288,46 @@ mod tests {
                 span: Some(Utf8Span::new(4, 11)),
             }]
         );
+    }
+
+    #[test]
+    fn cairo_version_mismatch_errors_get_dedicated_message() {
+        let stdout = "{\"type\":\"error\",\"message\":\"the required Cairo version of package \
+                      sphincs_plus is not compatible with current version\\nCairo version \
+                      required: =2.1.0\\nCairo version of Scarb: 2.18.0\\n\"}\n{\"type\":\"error\",\
+                      \"message\":\"the required Cairo version of each package must match the \
+                      current Cairo version\\nhelp: pass `--ignore-cairo-version` to ignore Cairo \
+                      version mismatch\"}";
+
+        let messages = collect_scarb_manifest_diagnostics(MetadataCommandError::ScarbError {
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        });
+
+        assert_eq!(
+            scarb_metadata_failed_message(&messages),
+            SCARB_METADATA_CAIRO_VERSION_MISMATCH_MESSAGE
+        );
+    }
+
+    #[test]
+    fn generic_metadata_errors_get_generic_message() {
+        let messages =
+            vec![ScarbMetadataMessage::MetadataError("something else went wrong".to_string())];
+
+        assert_eq!(scarb_metadata_failed_message(&messages), SCARB_METADATA_FAILED_MESSAGE);
+    }
+
+    #[test]
+    fn located_manifest_diagnostics_get_generic_message() {
+        let messages = vec![ScarbMetadataMessage::MetadataDiagnostic {
+            path: PathBuf::from("/tmp/Scarb.toml"),
+            message: "profile name `test` is not allowed".to_string(),
+            error_code: None,
+            span: Some(Utf8Span::new(4, 11)),
+        }];
+
+        assert_eq!(scarb_metadata_failed_message(&messages), SCARB_METADATA_FAILED_MESSAGE);
     }
 
     #[test]

--- a/src/toolchain/scarb.rs
+++ b/src/toolchain/scarb.rs
@@ -17,6 +17,9 @@ use crate::server::client::Notifier;
 pub const SCARB_TOML: &str = "Scarb.toml";
 pub const SCARB_METADATA_FAILED_MESSAGE: &str =
     "`scarb metadata` failed. Check if your project builds correctly via `scarb build`.";
+pub const SCARB_METADATA_CAIRO_VERSION_MISMATCH_MESSAGE: &str = "`scarb metadata` failed due to a Cairo version requirement mismatch. The Cairo version \
+     required by your project is not compatible with the version of Scarb in use. Adjust the \
+     `cairo-version` field in your `Scarb.toml` or switch to a matching Scarb toolchain.";
 
 pub struct MetadataOutput {
     pub metadata: Metadata,
@@ -152,7 +155,7 @@ impl ScarbToolchain {
             .context("failed to execute: scarb metadata");
 
         if !self.is_silent && result.is_err() {
-            self.notify_metadata_failed();
+            self.notify_metadata_failed(SCARB_METADATA_FAILED_MESSAGE);
         }
 
         result
@@ -187,10 +190,10 @@ impl ScarbToolchain {
         })
     }
 
-    pub fn notify_metadata_failed(&self) {
+    pub fn notify_metadata_failed(&self, message: &str) {
         self.notifier.notify::<ShowMessage>(ShowMessageParams {
             typ: MessageType::ERROR,
-            message: SCARB_METADATA_FAILED_MESSAGE.to_string(),
+            message: message.to_string(),
         });
     }
 


### PR DESCRIPTION
The cairo-version field in manifest may require different scarb/cairo toolchain version than currently available. In this case, emit a more specific popup instead of generic "metadata failed" error

