### PR TITLE
Adjust debugger validation logic

### DIFF
--- a/src/ide/code_lens/debugger.rs
+++ b/src/ide/code_lens/debugger.rs
@@ -42,10 +42,11 @@ impl CodeLensInterface for DebuggerCodeLens {
                     Cannot launch debugger: the Cairo compiler is not configured for debugging.
                     Add the following key-value pairs your Scarb.toml to `[profile.dev.cairo]` section:
 
-                    unstable-add-statements-code-locations-debug-info = true
-                    unstable-add-statements-functions-debug-info = true
-                    add-functions-debug-info = true
                     skip-optimizations = true
+                    add-statements-code-locations-debug-info = true
+                    add-statements-functions-debug-info = true
+                    add-functions-debug-info = true
+                    add-types-debug-info = true
                 "#}
                     .to_string(),
             });

--- a/src/project/model/configs_registry/package_config.rs
+++ b/src/project/model/configs_registry/package_config.rs
@@ -68,5 +68,6 @@ fn check_compiler_config_for_debugging(config: &Value) -> bool {
     bool_field("add_functions_debug_info")
         && bool_field("add_statements_code_locations_debug_info")
         && bool_field("add_statements_functions_debug_info")
+        && bool_field("add_types_debug_info")
         && str_field("compiler_optimizations") == "Disabled"
 }

--- a/tests/e2e/code_lens/mod.rs
+++ b/tests/e2e/code_lens/mod.rs
@@ -59,6 +59,7 @@ fn test_code_lens_snforge(cairo_code: &str) -> Report {
             skip-optimizations = true
             unstable-add-statements-code-locations-debug-info = true
             add-statements-functions-debug-info = true
+            add-types-debug-info = true
             "#
         ),
         json!({

--- a/tests/e2e/code_lens/snforge.rs
+++ b/tests/e2e/code_lens/snforge.rs
@@ -427,10 +427,11 @@ fn debug_with_incorrect_compiler_config() {
     Cannot launch debugger: the Cairo compiler is not configured for debugging.
     Add the following key-value pairs your Scarb.toml to `[profile.dev.cairo]` section:
 
-    unstable-add-statements-code-locations-debug-info = true
-    unstable-add-statements-functions-debug-info = true
-    add-functions-debug-info = true
     skip-optimizations = true
+    add-statements-code-locations-debug-info = true
+    add-statements-functions-debug-info = true
+    add-functions-debug-info = true
+    add-types-debug-info = true
     """
 
     [[execute_in_terminal]]


### PR DESCRIPTION
Require `add-types-debug-info = true` when launching debugger via code lens.

These annotations are available from Scarb 2.19.0 onwards and improve the debugging UX drastically if used with snforge >= 0.62.0 (new `cairo-debugger` uses types debug info annotations). Adding them won't hurt if the previous version of snforge is used.

Since LS is shipped with Scarb we can add this check with no risk.