### PR TITLE
Bump Cairo to 2.20.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,8 +258,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae87d4042e1005764d3b1580c52648630629ad270b5153a5e38728dad188e3c"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -271,8 +272,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-compiler"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1091923b522e02e0c6fbe8fb9f31ce854b2e6ab9a77d65c2b7a8e0aa1e6066"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -297,8 +299,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-debug"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c351a4e3c0a827812e3e04634b385a1e73c243e5920b1ea6baa8f7388bb47f24"
 dependencies = [
  "cairo-lang-utils",
  "id-arena",
@@ -307,8 +310,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-defs"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9b1b95e08edff0e1f305a0157e4af477ee92f518f0b2f2060a5551c7244dda"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -328,8 +332,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-diagnostics"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35e977fc967851424e4772e4aaeb26cdd85cbda75de0435f564238229e0bf540"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -341,8 +346,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-doc"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bca6936f26efbd7370e35fe0b6eaa8818f6163dec09059b81a815ee9ed2c86"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -360,8 +366,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-eq-solver"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eae9c6e46142cbb537fcdc883dbb3ea3101bf2347bfac52c7c9d00776b24220"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -369,8 +376,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-executable-plugin"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "781631ee50282f89e0440373c47e4ebcf818adf573737f0e126ea98c257886e2"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-filesystem",
@@ -383,8 +391,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-filesystem"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dae5ee7e470b9449da7d1459d183f5f57400b7044f6ac8df10f37c53dfc3c95"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-proc-macros",
@@ -400,8 +409,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-formatter"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1324b016cdda1f2cfae0686c76f998e07109aead1fccd7fb7a03af789db4a"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -419,8 +429,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-lowering"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161a6ae4f2e076019f5bf2d9895d04f271cb87b43573a55e67243b0d247588bb"
 dependencies = [
  "assert_matches",
  "cairo-lang-debug",
@@ -536,8 +547,9 @@ checksum = "414b7ba40b5ec3f26101b5c76df5739190832834b95689a723f3f88ec1695fe3"
 
 [[package]]
 name = "cairo-lang-parser"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b974bf47d62aedf3b0fbc8d02d033c037593a86659d75b0a36d5fd784aa07ff"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -555,8 +567,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-plugins"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e759400a233617dd24b7613e8bd9f1dcb964bcfa97090d7ac587e001eb12814"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -578,8 +591,9 @@ checksum = "123ac0ecadf31bacae77436d72b88fa9caef2b8e92c89ce63a125ae911a12fae"
 
 [[package]]
 name = "cairo-lang-proc-macros"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ff5a6ebc7548ba94098669b0ac3840da4dcdf5e510a1fc1389bdbf9bb365"
 dependencies = [
  "cairo-lang-debug",
  "proc-macro2",
@@ -590,8 +604,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-project"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc9ae071e386a9f85941d6a8f9f8fe4b610b1cf54fbae5e5fd4889f4eed42df"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -623,8 +638,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-runnable-utils"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791262a0cedf700f8d60d3e4661f6328c21f0d23ed0da72d40e7fb32e0dae2fa"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -639,8 +655,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-semantic"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc666d47999629cc46a62695185f5481375ef94df0a5dc6126b32c2b46bec3a6"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -668,8 +685,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481fe2ddc14a5b1a0d346a2075d8d7d0831fcb2bffc7d6a440504794b8d31dc"
 dependencies = [
  "anyhow",
  "cairo-lang-utils",
@@ -693,8 +711,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-ap-change"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0009c2e5b1bd235503113bcc4656dc8ec75450822386fd5869ac6d00e636c660"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -708,8 +727,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-gas"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d48d5362326efa7d91be0a601dc9894f17cabb943b83c81613a16f099c8a413"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -723,8 +743,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-generator"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae06a529a0e1ccf0b5da74ce440a864964fc25fb620355147f8ce817adcad2f"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -747,8 +768,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-to-casm"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa86c03e87e2cb0735dcc206978393701a118d6b3de1e2c731bbbe48006583d"
 dependencies = [
  "assert_matches",
  "cairo-lang-casm",
@@ -767,8 +789,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5b7ddab664fc109cf369c534c547ee163acf9b8c4fc645058a11a69e59dcb5"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-utils",
@@ -776,8 +799,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f9731ec1885d45bf985036b53e51df7c3af571b1ff9bef565ab454d8063475"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -808,8 +832,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f64c7b722bb48f76b320a2e9de47c426fd12c5a93cd14a1b1a2980d3a466119"
 dependencies = [
  "cairo-lang-casm",
  "cairo-lang-sierra",
@@ -831,8 +856,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902004e29d74ee3d7ef69c8c48593948b954a3bba79c4f8e959de690aadbd92d"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -849,8 +875,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-syntax-codegen"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85df773db0206a141b29afba01ebaf94a020fb7bb564fb3b675ba0e7ce5b07c3"
 dependencies = [
  "genco",
  "xshell",
@@ -858,8 +885,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-plugin"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea99e63380f34dee313a22677b69030276d955f9227678cceb16ca7459e9330"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -886,8 +914,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-test-utils"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bacc435fa248727ae1652f8cce4b20fa6ed93f2d0ee339cf9e68f43402a4da0a"
 dependencies = [
  "cairo-lang-formatter",
  "cairo-lang-proc-macros",
@@ -899,8 +928,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-utils"
-version = "2.19.2"
-source = "git+https://github.com/starkware-libs/cairo?rev=b585bc3ab77e7b6ac7741558fb12684609036f37#b585bc3ab77e7b6ac7741558fb12684609036f37"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76f2e9903cc6fd4ceee97d3ebe5c45adbbf2d6ba02db403066292d796639fee"
 dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
@@ -919,8 +949,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-language-common"
-version = "2.15.0"
-source = "git+https://github.com/software-mansion/cairo-language-common?rev=994df676e5c52cb6e2241d4ac9184cf855b39b21#994df676e5c52cb6e2241d4ac9184cf855b39b21"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0b3416b387e529d6a25c96af7e5aaabc6c35e3fcdab8927e40a5e246d3496a"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -936,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "cairo-language-server"
-version = "2.19.2"
+version = "2.20.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -1002,8 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-lint"
-version = "2.15.0"
-source = "git+https://github.com/software-mansion/cairo-lint?rev=149eb7cbd8bf61587373b942c1dbb4b21e824ea7#149eb7cbd8bf61587373b942c1dbb4b21e824ea7"
+version = "2.20.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ba94de3e9ee3a0ab4097ed0c7022b7849b1bb627f048309093ad9b11775eee7"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cairo-language-server"
-version = "2.19.2"
+version = "2.20.0-rc.1"
 edition = "2024"
 
 authors = ["Software Mansion <contact@swmansion.com>", "StarkWare <info@starkware.co>"]
@@ -32,28 +32,28 @@ testing = []
 [dependencies]
 anyhow = "1"
 bincode = { version = "2.0.1", default-features = true, features = ["serde"] }
-cairo-lang-compiler = "*"
-cairo-lang-defs = "*"
-cairo-lang-diagnostics = "*"
-cairo-lang-doc = "*"
-cairo-lang-executable-plugin = "*"
-cairo-lang-filesystem = "*"
-cairo-lang-formatter = "*"
-cairo-lang-lowering = "*"
+cairo-lang-compiler = "2.20.0-rc.1"
+cairo-lang-defs = "2.20.0-rc.1"
+cairo-lang-diagnostics = "2.20.0-rc.1"
+cairo-lang-doc = "2.20.0-rc.1"
+cairo-lang-executable-plugin = "2.20.0-rc.1"
+cairo-lang-filesystem = "2.20.0-rc.1"
+cairo-lang-formatter = "2.20.0-rc.1"
+cairo-lang-lowering = "2.20.0-rc.1"
 cairo-lang-macro = "0.2.1"
 cairo-lang-macro-v1 = { version = "0.1", package = "cairo-lang-macro", features = ["serde"] }
-cairo-lang-parser = "*"
-cairo-lang-plugins = "*"
-cairo-lang-proc-macros = "*"
-cairo-lang-project = "*"
-cairo-lang-semantic = "*"
-cairo-lang-starknet = "*"
-cairo-lang-syntax = "*"
-cairo-lang-syntax-codegen = "*"
-cairo-lang-test-plugin = "*"
-cairo-lang-utils = "*"
-cairo-language-common = "*"
-cairo-lint = "*"
+cairo-lang-parser = "2.20.0-rc.1"
+cairo-lang-plugins = "2.20.0-rc.1"
+cairo-lang-proc-macros = "2.20.0-rc.1"
+cairo-lang-project = "2.20.0-rc.1"
+cairo-lang-semantic = "2.20.0-rc.1"
+cairo-lang-starknet = "2.20.0-rc.1"
+cairo-lang-syntax = "2.20.0-rc.1"
+cairo-lang-syntax-codegen = "2.20.0-rc.1"
+cairo-lang-test-plugin = "2.20.0-rc.1"
+cairo-lang-utils = "2.20.0-rc.1"
+cairo-language-common = "2.20.0-rc.1"
+cairo-lint = "2.20.0-rc.1"
 colored = "3.1.1"
 convert_case = "0.11.0"
 create-output-dir = "1.0.0"
@@ -101,38 +101,6 @@ similar = "3.1"
 # on some of them directly.
 # This ensures no duplicate instances of Cairo crates are pulled in by mistake.
 [patch.crates-io]
-cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-doc = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-eq-solver = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-executable-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-proc-macros = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-runnable-utils = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra-ap-change = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra-gas = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-sierra-type-size = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-starknet-classes = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-syntax-codegen = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-test-plugin = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo", rev = "b585bc3ab77e7b6ac7741558fb12684609036f37" }
-cairo-language-common = { git = "https://github.com/software-mansion/cairo-language-common", rev = "994df676e5c52cb6e2241d4ac9184cf855b39b21" }
-cairo-lint = { git = "https://github.com/software-mansion/cairo-lint", rev = "149eb7cbd8bf61587373b942c1dbb4b21e824ea7" }
 # The profile used for CI in pull requests.
 # External dependencies are built with optimisation enabled,
 # while crates in this workspace are built with `dev` profile and full debug info.


### PR DESCRIPTION
Bumps cairo-language-server to 2.20.0-rc.1 and updates Cairo-related dependencies to the 2.20.0-rc.1 crates.io release, including cairo-language-common and cairo-lint 2.20.0-rc.1.