### PR TITLE
Use unbounded channels for communication with proc-macro-server

### DIFF
--- a/src/lang/proc_macros/client/connection.rs
+++ b/src/lang/proc_macros/client/connection.rs
@@ -28,7 +28,7 @@ impl ProcMacroServerConnection {
         let server_input =
             proc_macro_server.stdin.take().expect("proc-macro-server must use pipe on stdin");
 
-        let (requester, receiver) = crossbeam::channel::bounded(0);
+        let (requester, receiver) = crossbeam::channel::unbounded();
         let (server_killed_sender, server_killed_receiver) = trigger::trigger();
 
         let responses: Arc<Mutex<VecDeque<RpcResponse>>> = Default::default();


### PR DESCRIPTION
Related to https://github.com/software-mansion/maat/issues/101

Communication with proc-macro-server using `bounded(0)` channels is synchronous. This results in a deadlock in a very specific scenario:

Suppose all workers in PMS are busy. In the current implementation of PMS (without internal buffering between its stages), the server stops consuming its `stdin`. When the following things happen simultaneously:
1. Diagnostic worker thread requests a macro expansion → it calls `send_request` that acquires a mutex on `requests_params` and blocks on write to PMS' `stdin` because it's full and PMS is not consuming it
2. Main loop calls `available_responses` that acquires a mutex on `responses` deque but blocks waiting for `requests_params` (because it's being held by the diagnostic worker)
3. A thread that reads PMS' `stdout` blocks waiting for `responses` mutex that is being held by the main loop and stops consuming the `stdout`

**As a consequence in PMS:** `stdout` is full, no worker can write its result into it, and thus can't consume `stdin`, which closes the loop.

Sibling PR in Scarb that fixes the internal flow in PMS: https://github.com/software-mansion/scarb/pull/3183

**Note that it would be enough to change the channels from bounded to unbounded in only one place**. However, a flow with buffering on both sides is **generally safer and more natural**. Fix on the LS' side is necessary, while the fix on the PMS' side ensures correctness regardless of the future use.