### PR TITLE
Migrate semantic tokens tests to `Transformer` infrastructure

### DIFF
--- a/tests/e2e/semantic_tokens/complex.rs
+++ b/tests/e2e/semantic_tokens/complex.rs
@@ -1,9 +1,10 @@
-use crate::semantic_tokens::semantic_tokens;
-use crate::support::insta::test_transform;
+use lsp_types::SemanticTokens;
+
+use crate::support::insta::test_transform_plain;
 
 #[test]
 fn complex() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     enum Foo {
         Bar,
         Baz,
@@ -60,7 +61,7 @@ fn complex() {
 
 #[test]
 fn multiline() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     fn main() {
         let _ = "
         ";
@@ -75,7 +76,7 @@ fn multiline() {
 
 #[test]
 fn on_mod() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     #[cfg(test, 1234)]
     mod rectangle { }
     "#, @r"
@@ -86,7 +87,7 @@ fn on_mod() {
 
 #[test]
 fn on_fn() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     #[cfg(test, 1234)]
     fn rectangle() { }
     "#, @r"
@@ -97,7 +98,7 @@ fn on_fn() {
 
 #[test]
 fn consts() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     const STANDALONE: u32 = 3;
 
     trait Shape<T> {
@@ -132,7 +133,7 @@ fn consts() {
 
 #[test]
 fn inline_macro_with_same_name_as_module() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     use core::array;
 
     fn main() {
@@ -149,7 +150,7 @@ fn inline_macro_with_same_name_as_module() {
 
 #[test]
 fn inline_macro_with_same_name_as_enum() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     enum array {
         Abc
     }
@@ -170,7 +171,7 @@ fn inline_macro_with_same_name_as_enum() {
 
 #[test]
 fn inline_macro_with_same_name_as_trait() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     trait array { }
 
     fn main() {
@@ -187,7 +188,7 @@ fn inline_macro_with_same_name_as_trait() {
 
 #[test]
 fn doc_comment_with_link() {
-    test_transform!(semantic_tokens, r#"
+    test_transform_plain!(SemanticTokens, r#"
     //! Doc header comment
     //! And a one with a [`Link`]
     //! Plz refer to this external [source](https://zal.pl)

--- a/tests/e2e/semantic_tokens/mod.rs
+++ b/tests/e2e/semantic_tokens/mod.rs
@@ -1,80 +1,80 @@
 use cairo_language_server::testing::SemanticTokenKind;
-use lsp_types::{Position, Range, lsp_request};
+use lsp_types::{
+    ClientCapabilities, Position, Range, SemanticTokens, SemanticTokensClientCapabilities,
+    SemanticTokensClientCapabilitiesRequests, SemanticTokensFullOptions, SemanticTokensParams,
+    SemanticTokensResult, TextDocumentClientCapabilities, lsp_request,
+};
 
-use crate::support::cairo_project_toml::CAIRO_PROJECT_TOML_2023_11;
-use crate::support::cursor::render_text_with_annotations;
-use crate::support::sandbox;
+use crate::support::MockClient;
+use crate::support::cursor::{Cursors, render_text_with_annotations};
+use crate::support::transform::Transformer;
 
 mod complex;
 
-fn semantic_tokens(code: &str) -> String {
-    let mut ls = sandbox! {
-        files {
-            "cairo_project.toml" => CAIRO_PROJECT_TOML_2023_11,
-            "src/lib.cairo" => code,
-        }
-        client_capabilities = caps;
-    };
-
-    ls.open_all_cairo_files_and_wait_for_project_update();
-
-    let res = ls
-        .send_request::<lsp_request!("textDocument/semanticTokens/full")>(
-            lsp_types::SemanticTokensParams {
-                work_done_progress_params: Default::default(),
-                partial_result_params: Default::default(),
-                text_document: ls.doc_id("src/lib.cairo"),
-            },
-        )
-        .unwrap();
-    let lsp_types::SemanticTokensResult::Tokens(tokens) = res else {
-        panic!("expected full tokens")
-    };
-
-    let mut line = 0;
-    let mut character = 0;
-
-    let legend = SemanticTokenKind::legend();
-
-    let tokens: Vec<_> = tokens
-        .data
-        .into_iter()
-        .map(|token| {
-            // Reset on new line.
-            if token.delta_line != 0 {
-                character = 0;
-            }
-
-            line += token.delta_line;
-            character += token.delta_start;
-
-            let start = Position { character, line };
-            let end = Position { character: start.character + token.length, ..start };
-
-            let token_type = legend[token.token_type as usize].as_str().to_string();
-
-            (Range { start, end }, Some(token_type))
-        })
-        .collect();
-
-    render_text_with_annotations(code, "token", &tokens)
-}
-
-fn caps(base: lsp_types::ClientCapabilities) -> lsp_types::ClientCapabilities {
-    lsp_types::ClientCapabilities {
-        text_document: base.text_document.or_else(Default::default).map(|it| {
-            lsp_types::TextDocumentClientCapabilities {
-                semantic_tokens: Some(lsp_types::SemanticTokensClientCapabilities {
-                    dynamic_registration: Some(false),
-                    requests: lsp_types::SemanticTokensClientCapabilitiesRequests {
-                        full: Some(lsp_types::SemanticTokensFullOptions::Bool(true)),
+impl Transformer for SemanticTokens {
+    fn capabilities(base: ClientCapabilities) -> ClientCapabilities {
+        ClientCapabilities {
+            text_document: base.text_document.or_else(Default::default).map(|it| {
+                TextDocumentClientCapabilities {
+                    semantic_tokens: Some(SemanticTokensClientCapabilities {
+                        dynamic_registration: Some(false),
+                        requests: SemanticTokensClientCapabilitiesRequests {
+                            full: Some(SemanticTokensFullOptions::Bool(true)),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                ..it
-            }
-        }),
-        ..base
+                    }),
+                    ..it
+                }
+            }),
+            ..base
+        }
+    }
+
+    fn transform(
+        mut ls: MockClient,
+        _cursors: Cursors,
+        _config: Option<serde_json::Value>,
+    ) -> String {
+        let code = ls.fixture.read_file("src/lib.cairo");
+
+        let res = ls
+            .send_request::<lsp_request!("textDocument/semanticTokens/full")>(
+                SemanticTokensParams {
+                    work_done_progress_params: Default::default(),
+                    partial_result_params: Default::default(),
+                    text_document: ls.doc_id("src/lib.cairo"),
+                },
+            )
+            .unwrap();
+        let SemanticTokensResult::Tokens(tokens) = res else { panic!("expected full tokens") };
+
+        let mut line = 0;
+        let mut character = 0;
+
+        let legend = SemanticTokenKind::legend();
+
+        let tokens: Vec<_> = tokens
+            .data
+            .into_iter()
+            .map(|token| {
+                // Reset on new line.
+                if token.delta_line != 0 {
+                    character = 0;
+                }
+
+                line += token.delta_line;
+                character += token.delta_start;
+
+                let start = Position { character, line };
+                let end = Position { character: start.character + token.length, ..start };
+
+                let token_type = legend[token.token_type as usize].as_str().to_string();
+
+                (Range { start, end }, Some(token_type))
+            })
+            .collect();
+
+        render_text_with_annotations(&code, "token", &tokens)
     }
 }


### PR DESCRIPTION
Implementing `Transformer` allows introducing tests of semantic highlighting inside proc macros in the next PR