### PR TITLE
Highlight the bang of nested inline macros as a macro

### DIFF
--- a/src/ide/semantic_highlighting/token_kind.rs
+++ b/src/ide/semantic_highlighting/token_kind.rs
@@ -140,7 +140,7 @@ impl SemanticTokenKind {
                 if matches!(
                     grandparent_kind,
                     Some(SyntaxKind::ExprInlineMacro | SyntaxKind::ItemInlineMacro)
-                ) =>
+                ) || is_token_tree_macro_bang(db, node) =>
             {
                 Some(SemanticTokenKind::InlineMacro)
             }
@@ -307,6 +307,43 @@ fn find_closest_terminal_ancestor_or_self<'db>(
         None
     }?;
     Some(TerminalIdentifier::cast(db, terminal)?.stable_ptr(db))
+}
+
+/// Checks whether a `!` token nested inside a token tree is the bang of a (nested) macro call.
+///
+/// A nested macro invocation like `array![array![x]]` is not parsed as an [`ast::ExprInlineMacro`];
+/// its inner `!` lives in the outer macro's token tree (or, inside a `macro` declaration body, in
+/// that rule's macro elements). We recognize it structurally: the `!` is preceded by an identifier
+/// and followed by a subtree wrapper of any delimiter (`()`, `[]` or `{}`).
+fn is_token_tree_macro_bang<'db>(db: &'db AnalysisDatabase, not_token: &SyntaxNode<'db>) -> bool {
+    let Some(leaf) = not_token.parent(db).and_then(|terminal| terminal.parent(db)) else {
+        return false;
+    };
+    if leaf.kind(db) != SyntaxKind::TokenTreeLeaf {
+        return false;
+    }
+    let Some(list) = leaf.parent(db) else {
+        return false;
+    };
+
+    let children = list.get_children(db);
+    let Some(position) = children.iter().position(|child| child.offset(db) == leaf.offset(db))
+    else {
+        return false;
+    };
+
+    let preceded_by_identifier = position
+        .checked_sub(1)
+        .and_then(|index| children.get(index))
+        .and_then(|previous| previous.get_children(db).first().copied())
+        .is_some_and(|token| token.kind(db) == SyntaxKind::TerminalIdentifier);
+    // The subtree after `!` is a `TokenTreeNode` inside inline-macro arguments, or a `MacroWrapper`
+    // inside a `macro` declaration body. Both wrap any delimiter (`()`, `[]`, `{}`).
+    let followed_by_subtree = children.get(position + 1).is_some_and(|next| {
+        matches!(next.kind(db), SyntaxKind::TokenTreeNode | SyntaxKind::MacroWrapper)
+    });
+
+    preceded_by_identifier && followed_by_subtree
 }
 
 /// Checks whether the given node is an inline macro invocation and not just the simple path segment.

--- a/tests/e2e/semantic_tokens/declarative_macros.rs
+++ b/tests/e2e/semantic_tokens/declarative_macros.rs
@@ -150,7 +150,6 @@ fn inline_macro_content_struct_literal() {
     ")
 }
 
-// Bug: the inner macro's `!` is colored as an operator instead of the macro.
 #[test]
 fn nested_inline_macros() {
     test_transform_plain!(SemanticTokens, r#"
@@ -161,7 +160,7 @@ fn nested_inline_macros() {
     "#, @r"
     <token=keyword>fn</token> <token=function>main</token>() {
         <token=keyword>let</token> <token=variable>x</token> = <token=number>5</token>;
-        <token=macro>array</token><token=macro>!</token>[<token=macro>array</token><token=operator>!</token>[<token=variable>x</token>]];
+        <token=macro>array</token><token=macro>!</token>[<token=macro>array</token><token=macro>!</token>[<token=variable>x</token>]];
     }
     ")
 }
@@ -245,7 +244,7 @@ fn module_level_user_macro() {
     "#, @r"
     <token=keyword>macro</token> <token=class>define_fn</token> {
         ($name:ident) => {
-            expose<token=operator>!</token> {
+            expose<token=macro>!</token> {
                 <token=keyword>fn</token> $name() -> felt252 {
                     <token=number>42</token>
                 }
@@ -257,6 +256,27 @@ fn module_level_user_macro() {
 
     <token=keyword>fn</token> <token=function>main</token>() -> <token=type>felt252</token> {
         <token=function>the_answer</token>()
+    }
+    ")
+}
+
+#[test]
+fn nested_bangs_in_macro_definition() {
+    test_transform_plain!(SemanticTokens, r#"
+    pub macro outer {
+        () => {
+            paren!(1);
+            bracket![2];
+            brace!{3}
+        };
+    }
+    "#, @r"
+    <token=keyword>pub</token> <token=keyword>macro</token> <token=class>outer</token> {
+        () => {
+            paren<token=macro>!</token>(<token=number>1</token>);
+            bracket<token=macro>!</token>[<token=number>2</token>];
+            brace<token=macro>!</token>{<token=number>3</token>}
+        };
     }
     ")
 }


### PR DESCRIPTION
A nested invocation like `array![array![x]]` is not parsed as an `ExprInlineMacro`;
its inner `!` lives in the outer macro's token tree, so it was highlighted as an
operator. Detect it structurally: a `!` preceded by an identifier and followed by a
bracketed token tree.