### PR TITLE
Highlight struct field access as a field

### DIFF
--- a/src/ide/semantic_highlighting/token_kind.rs
+++ b/src/ide/semantic_highlighting/token_kind.rs
@@ -1,19 +1,18 @@
 use cairo_lang_defs::ids::{GenericTypeId, LookupItemId, TraitItemId};
 use cairo_lang_semantic::db::SemanticGroup;
-use cairo_lang_semantic::items::function_with_body::{
-    FunctionWithBodySemantic, SemanticExprLookup,
-};
+use cairo_lang_semantic::items::function_with_body::SemanticExprLookup;
 use cairo_lang_semantic::keyword::{CRATE_KW, SELF_TYPE_KW, SUPER_KW};
 use cairo_lang_semantic::lookup_item::LookupItemEx;
 use cairo_lang_semantic::resolve::{ResolvedConcreteItem, ResolvedGenericItem};
-use cairo_lang_semantic::{ConcreteTypeId, Expr, MemberAccessKind, TypeLongId};
+use cairo_lang_semantic::{ConcreteTypeId, TypeLongId};
 use cairo_lang_syntax::node::ast::{TerminalIdentifier, TerminalIdentifierPtr};
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedStablePtr, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
 use cairo_language_common::CommonGroup;
 use lsp_types::SemanticTokenType;
 
 use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
+use crate::lang::defs::resolve_accessed_member;
 
 #[derive(Clone, Copy)]
 pub enum SemanticTokenKind {
@@ -302,36 +301,14 @@ impl SemanticTokenKind {
 
     /// Resolves the right-hand side of a struct member access expression (e.g. the `x` in `p.x`)
     /// to a [`SemanticTokenKind::Field`].
-    fn from_member_access(
-        db: &AnalysisDatabase,
-        resultant: SyntaxNode,
-        lookup_item_id: LookupItemId,
+    fn from_member_access<'db>(
+        db: &'db AnalysisDatabase,
+        resultant: SyntaxNode<'db>,
+        lookup_item_id: LookupItemId<'db>,
     ) -> Option<SemanticTokenKind> {
         let function_id = lookup_item_id.function_with_body()?;
-        let binary_expr = resultant.ancestor_of_type::<ast::ExprBinary>(db)?;
 
-        let expr_id = db.lookup_expr_by_ptr(function_id, binary_expr.stable_ptr(db).into()).ok()?;
-        let member_access = match db.expr_semantic(function_id, expr_id) {
-            Expr::MemberAccess(member_access) => member_access,
-            Expr::Snapshot(snapshot) => match db.expr_semantic(function_id, snapshot.inner) {
-                Expr::MemberAccess(member_access) => member_access,
-                _ => return None,
-            },
-            _ => return None,
-        };
-
-        // Make sure the resultant is the accessed member (the rhs), not the accessed value (lhs).
-        let rhs_ptr = binary_expr.rhs(db).stable_ptr(db).untyped();
-        let mut node = resultant;
-        while node.stable_ptr(db) != rhs_ptr {
-            if node.stable_ptr(db) == binary_expr.stable_ptr(db).untyped() {
-                return None;
-            }
-            node = node.parent(db)?;
-        }
-
-        matches!(member_access.kind, MemberAccessKind::Struct { .. })
-            .then_some(SemanticTokenKind::Field)
+        resolve_accessed_member(db, resultant, function_id).map(|_| SemanticTokenKind::Field)
     }
 }
 

--- a/src/ide/semantic_highlighting/token_kind.rs
+++ b/src/ide/semantic_highlighting/token_kind.rs
@@ -1,13 +1,15 @@
 use cairo_lang_defs::ids::{GenericTypeId, LookupItemId, TraitItemId};
 use cairo_lang_semantic::db::SemanticGroup;
-use cairo_lang_semantic::items::function_with_body::SemanticExprLookup;
+use cairo_lang_semantic::items::function_with_body::{
+    FunctionWithBodySemantic, SemanticExprLookup,
+};
 use cairo_lang_semantic::keyword::{CRATE_KW, SELF_TYPE_KW, SUPER_KW};
 use cairo_lang_semantic::lookup_item::LookupItemEx;
 use cairo_lang_semantic::resolve::{ResolvedConcreteItem, ResolvedGenericItem};
-use cairo_lang_semantic::{ConcreteTypeId, TypeLongId};
+use cairo_lang_semantic::{ConcreteTypeId, Expr, MemberAccessKind, TypeLongId};
 use cairo_lang_syntax::node::ast::{TerminalIdentifier, TerminalIdentifierPtr};
 use cairo_lang_syntax::node::kind::SyntaxKind;
-use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{SyntaxNode, Terminal, TypedStablePtr, TypedSyntaxNode, ast};
 use cairo_language_common::CommonGroup;
 use lsp_types::SemanticTokenType;
 
@@ -93,6 +95,10 @@ impl SemanticTokenKind {
                     }
 
                     if let Some(kind) = Self::from_expr_path(db, *resultant, *lookup_item_id) {
+                        return Some(kind);
+                    }
+
+                    if let Some(kind) = Self::from_member_access(db, *resultant, *lookup_item_id) {
                         return Some(kind);
                     }
                 }
@@ -292,6 +298,40 @@ impl SemanticTokenKind {
         db.lookup_pattern_by_ptr(function_id, expr_path_ptr.into()).ok()?;
 
         Some(SemanticTokenKind::Variable)
+    }
+
+    /// Resolves the right-hand side of a struct member access expression (e.g. the `x` in `p.x`)
+    /// to a [`SemanticTokenKind::Field`].
+    fn from_member_access(
+        db: &AnalysisDatabase,
+        resultant: SyntaxNode,
+        lookup_item_id: LookupItemId,
+    ) -> Option<SemanticTokenKind> {
+        let function_id = lookup_item_id.function_with_body()?;
+        let binary_expr = resultant.ancestor_of_type::<ast::ExprBinary>(db)?;
+
+        let expr_id = db.lookup_expr_by_ptr(function_id, binary_expr.stable_ptr(db).into()).ok()?;
+        let member_access = match db.expr_semantic(function_id, expr_id) {
+            Expr::MemberAccess(member_access) => member_access,
+            Expr::Snapshot(snapshot) => match db.expr_semantic(function_id, snapshot.inner) {
+                Expr::MemberAccess(member_access) => member_access,
+                _ => return None,
+            },
+            _ => return None,
+        };
+
+        // Make sure the resultant is the accessed member (the rhs), not the accessed value (lhs).
+        let rhs_ptr = binary_expr.rhs(db).stable_ptr(db).untyped();
+        let mut node = resultant;
+        while node.stable_ptr(db) != rhs_ptr {
+            if node.stable_ptr(db) == binary_expr.stable_ptr(db).untyped() {
+                return None;
+            }
+            node = node.parent(db)?;
+        }
+
+        matches!(member_access.kind, MemberAccessKind::Struct { .. })
+            .then_some(SemanticTokenKind::Field)
     }
 }
 

--- a/src/lang/defs/finder.rs
+++ b/src/lang/defs/finder.rs
@@ -28,7 +28,7 @@ use cairo_lang_semantic::resolve::{
     ResolverData,
 };
 use cairo_lang_semantic::substitution::SemanticRewriter;
-use cairo_lang_semantic::{ConcreteImplId, Expr, GenericParam, MemberAccessKind, TypeLongId};
+use cairo_lang_semantic::{ConcreteImplId, Expr, GenericParam, TypeLongId};
 use cairo_lang_syntax::node::ast::{
     ExprPathInner, GenericArgUnnamed, PathSegment, TerminalIdentifier, TypeClause,
 };
@@ -40,7 +40,7 @@ use cairo_lang_utils::Intern;
 use itertools::Itertools;
 
 use crate::lang::db::{AnalysisDatabase, LsSemanticGroup};
-use crate::lang::defs::resolve_macro_call_module;
+use crate::lang::defs::{resolve_accessed_member, resolve_macro_call_module};
 
 /// A language element that can be a result of name resolution performed by CairoLS.
 ///
@@ -411,48 +411,10 @@ fn try_member<'db>(
     identifier: &ast::TerminalIdentifier<'db>,
     lookup_items: &[LookupItemId<'db>],
 ) -> Option<ResolvedItem<'db>> {
-    let syntax_node = identifier.as_syntax_node();
-    let binary_expr = syntax_node.ancestor_of_type::<ast::ExprBinary>(db)?;
-
     let function_with_body = lookup_items.first()?.function_with_body()?;
 
-    let expr_id =
-        db.lookup_expr_by_ptr(function_with_body, binary_expr.stable_ptr(db).into()).ok()?;
-    let semantic_db: &dyn SemanticGroup = db;
-    let semantic_expr = semantic_db.expr_semantic(function_with_body, expr_id);
-
-    // Desnap the binary expression to the member access expression.
-    let expr_member_access = match semantic_expr {
-        Expr::MemberAccess(expr_member_access) => Some(expr_member_access),
-        Expr::Snapshot(expr_snapshot) => {
-            if let Expr::MemberAccess(expr_member_access) =
-                semantic_db.expr_semantic(function_with_body, expr_snapshot.inner)
-            {
-                Some(expr_member_access)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }?;
-
-    let pointer_to_rhs = binary_expr.rhs(db).stable_ptr(db).untyped();
-
-    let mut current_node = syntax_node;
-    // Check if the terminal identifier points to a member, not a struct variable.
-    while pointer_to_rhs != current_node.stable_ptr(db) {
-        // If we found the node with the binary expression, then we're sure we won't find the
-        // node with the member.
-        if current_node.stable_ptr(db) == binary_expr.stable_ptr(db).untyped() {
-            return None;
-        }
-        current_node = current_node.parent(db).unwrap();
-    }
-
-    let MemberAccessKind::Struct { member_id, .. } = expr_member_access.kind else {
-        return None;
-    };
-    Some(ResolvedItem::Member(member_id))
+    resolve_accessed_member(db, identifier.as_syntax_node(), function_with_body)
+        .map(ResolvedItem::Member)
 }
 
 /// Resolve `struct Foo { <ident>: ... }` syntax.

--- a/src/lang/defs/member.rs
+++ b/src/lang/defs/member.rs
@@ -1,6 +1,10 @@
-use cairo_lang_defs::ids::{MemberId, NamedLanguageElementId};
+use cairo_lang_defs::ids::{FunctionWithBodyId, MemberId, NamedLanguageElementId};
+use cairo_lang_semantic::items::function_with_body::{
+    FunctionWithBodySemantic, SemanticExprLookup,
+};
+use cairo_lang_semantic::{Expr, MemberAccessKind};
 use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
-use cairo_lang_syntax::node::{SyntaxNode, TypedSyntaxNode, ast};
+use cairo_lang_syntax::node::{SyntaxNode, TypedStablePtr, TypedSyntaxNode, ast};
 
 use crate::lang::db::AnalysisDatabase;
 use crate::lang::defs::ItemDef;
@@ -44,4 +48,47 @@ impl<'db> MemberDef<'db> {
     pub fn name(&self, db: &'db AnalysisDatabase) -> String {
         self.member_id.name(db).to_string(db)
     }
+}
+
+/// Resolves the member accessed by a member access expression (e.g. `self.<ident>`) containing
+/// `node`, if `node` is a part of the right-hand side of that expression.
+pub fn resolve_accessed_member<'db>(
+    db: &'db AnalysisDatabase,
+    node: SyntaxNode<'db>,
+    function_with_body: FunctionWithBodyId<'db>,
+) -> Option<MemberId<'db>> {
+    let binary_expr = node.ancestor_of_type::<ast::ExprBinary>(db)?;
+
+    let expr_id =
+        db.lookup_expr_by_ptr(function_with_body, binary_expr.stable_ptr(db).into()).ok()?;
+
+    // Desnap the binary expression to the member access expression.
+    let expr_member_access = match db.expr_semantic(function_with_body, expr_id) {
+        Expr::MemberAccess(expr_member_access) => expr_member_access,
+        Expr::Snapshot(expr_snapshot) => {
+            match db.expr_semantic(function_with_body, expr_snapshot.inner) {
+                Expr::MemberAccess(expr_member_access) => expr_member_access,
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+
+    let pointer_to_rhs = binary_expr.rhs(db).stable_ptr(db).untyped();
+
+    let mut current_node = node;
+    // Check if the node points to a member, not a struct variable.
+    while pointer_to_rhs != current_node.stable_ptr(db) {
+        // If we found the node with the binary expression, then we're sure we won't find the
+        // node with the member.
+        if current_node.stable_ptr(db) == binary_expr.stable_ptr(db).untyped() {
+            return None;
+        }
+        current_node = current_node.parent(db)?;
+    }
+
+    let MemberAccessKind::Struct { member_id, .. } = expr_member_access.kind else {
+        return None;
+    };
+    Some(member_id)
 }

--- a/src/lang/defs/member.rs
+++ b/src/lang/defs/member.rs
@@ -62,16 +62,19 @@ pub fn resolve_accessed_member<'db>(
     let expr_id =
         db.lookup_expr_by_ptr(function_with_body, binary_expr.stable_ptr(db).into()).ok()?;
 
-    // Desnap the binary expression to the member access expression.
-    let expr_member_access = match db.expr_semantic(function_with_body, expr_id) {
-        Expr::MemberAccess(expr_member_access) => expr_member_access,
-        Expr::Snapshot(expr_snapshot) => {
-            match db.expr_semantic(function_with_body, expr_snapshot.inner) {
-                Expr::MemberAccess(expr_member_access) => expr_member_access,
-                _ => return None,
+    // Accessing a member through a snapshot wraps the member access in snapshot and desnap
+    // expressions (e.g. `self.x` where `self: @Point` is a desnap of the member access),
+    // so unwrap them to get to the member access itself.
+    let mut semantic_expr = db.expr_semantic(function_with_body, expr_id);
+    let expr_member_access = loop {
+        semantic_expr = match semantic_expr {
+            Expr::MemberAccess(expr_member_access) => break expr_member_access,
+            Expr::Snapshot(expr_snapshot) => {
+                db.expr_semantic(function_with_body, expr_snapshot.inner)
             }
-        }
-        _ => return None,
+            Expr::Desnap(expr_desnap) => db.expr_semantic(function_with_body, expr_desnap.inner),
+            _ => return None,
+        };
     };
 
     let pointer_to_rhs = binary_expr.rhs(db).stable_ptr(db).untyped();

--- a/src/lang/defs/mod.rs
+++ b/src/lang/defs/mod.rs
@@ -17,7 +17,7 @@ pub use self::finder::ResolvedItem;
 pub use self::finder::{find_declaration, find_definition};
 pub use self::generic_param::GenericParamDef;
 pub use self::item::ItemDef;
-pub use self::member::MemberDef;
+pub use self::member::{MemberDef, resolve_accessed_member};
 pub use self::module::ModuleDef;
 pub use self::variable::VariableDef;
 pub use self::variant::VariantDef;

--- a/tests/e2e/goto_definition/structs.rs
+++ b/tests/e2e/goto_definition/structs.rs
@@ -46,6 +46,63 @@ fn struct_member_via_field_access() {
 }
 
 #[test]
+fn struct_member_via_field_access_on_snapshot() {
+    test_transform_plain!(GotoDefinition, r"
+    #[derive(Drop)]
+    struct Circle { radius: u64 }
+    fn foo(circle: @Circle) -> u64 {
+        *circle.rad<caret>ius
+    }
+    ", @r"
+    #[derive(Drop)]
+    struct Circle { <sel>radius</sel>: u64 }
+    fn foo(circle: @Circle) -> u64 {
+        *circle.radius
+    }
+    ")
+}
+
+#[test]
+fn struct_member_via_field_access_on_self_snapshot() {
+    test_transform_plain!(GotoDefinition, r"
+    #[derive(Drop)]
+    struct Circle { radius: u64 }
+    #[generate_trait]
+    impl CircleImpl of CircleTrait {
+        fn radius(self: @Circle) -> u64 {
+            *self.rad<caret>ius
+        }
+    }
+    ", @r"
+    #[derive(Drop)]
+    struct Circle { <sel>radius</sel>: u64 }
+    #[generate_trait]
+    impl CircleImpl of CircleTrait {
+        fn radius(self: @Circle) -> u64 {
+            *self.radius
+        }
+    }
+    ")
+}
+
+#[test]
+fn struct_member_via_snapshot_of_field_access() {
+    test_transform_plain!(GotoDefinition, r"
+    #[derive(Drop)]
+    struct Circle { radius: u64 }
+    fn foo(circle: Circle) -> @u64 {
+        @circle.rad<caret>ius
+    }
+    ", @r"
+    #[derive(Drop)]
+    struct Circle { <sel>radius</sel>: u64 }
+    fn foo(circle: Circle) -> @u64 {
+        @circle.radius
+    }
+    ")
+}
+
+#[test]
 fn struct_member_in_constructor() {
     test_transform_plain!(GotoDefinition, r"
     #[derive(Drop)]

--- a/tests/e2e/semantic_tokens/complex.rs
+++ b/tests/e2e/semantic_tokens/complex.rs
@@ -262,3 +262,69 @@ fn doc_comment_with_link() {
     }
     ")
 }
+
+#[test]
+fn field_access() {
+    test_transform_plain!(SemanticTokens, r#"
+    #[derive(Drop)]
+    struct Point {
+        x: felt252,
+    }
+
+    fn main() {
+        let point = Point { x: 5 };
+        let _ = point.x;
+    }
+    "#, @r"
+    #[<token=decorator>derive</token>(<token=decorator>Drop</token>)]
+    <token=keyword>struct</token> <token=struct>Point</token> {
+        <token=variable>x</token>: <token=type>felt252</token>,
+    }
+
+    <token=keyword>fn</token> <token=function>main</token>() {
+        <token=keyword>let</token> <token=variable>point</token> = <token=struct>Point</token> { <token=property>x</token>: <token=number>5</token> };
+        <token=keyword>let</token> _ = <token=variable>point</token>.<token=property>x</token>;
+    }
+    ")
+}
+
+#[test]
+fn field_access_through_snapshot() {
+    test_transform_plain!(SemanticTokens, r#"
+    #[derive(Drop)]
+    struct Point {
+        x: felt252,
+    }
+
+    #[generate_trait]
+    impl PointImpl of PointTrait {
+        fn get(self: @Point) -> felt252 {
+            *self.x
+        }
+    }
+
+    fn main() {
+        let point = Point { x: 5 };
+        let snapshot = @point;
+        let _ = *snapshot.x;
+    }
+    "#, @r"
+    #[<token=decorator>derive</token>(<token=decorator>Drop</token>)]
+    <token=keyword>struct</token> <token=struct>Point</token> {
+        <token=variable>x</token>: <token=type>felt252</token>,
+    }
+
+    #[<token=decorator>generate_trait</token>]
+    <token=keyword>impl</token> <token=class>PointImpl</token> <token=keyword>of</token> <token=interface>PointTrait</token> {
+        <token=keyword>fn</token> <token=function>get</token>(<token=parameter>self</token>: @<token=struct>Point</token>) -> <token=type>felt252</token> {
+            <token=operator>*</token><token=variable>self</token>.<token=property>x</token>
+        }
+    }
+
+    <token=keyword>fn</token> <token=function>main</token>() {
+        <token=keyword>let</token> <token=variable>point</token> = <token=struct>Point</token> { <token=property>x</token>: <token=number>5</token> };
+        <token=keyword>let</token> <token=variable>snapshot</token> = @<token=variable>point</token>;
+        <token=keyword>let</token> _ = <token=operator>*</token><token=variable>snapshot</token>.<token=property>x</token>;
+    }
+    ")
+}

--- a/tests/e2e/semantic_tokens/declarative_macros.rs
+++ b/tests/e2e/semantic_tokens/declarative_macros.rs
@@ -63,8 +63,6 @@ fn inline_macro_content_operators_and_literals() {
     "#)
 }
 
-// Bug: the field access `x` inside the invocation is colored as the macro instead
-// of a field.
 #[test]
 fn inline_macro_content_field_and_method() {
     test_transform_plain!(SemanticTokens, r#"
@@ -97,7 +95,7 @@ fn inline_macro_content_field_and_method() {
 
     <token=keyword>fn</token> <token=function>main</token>() {
         <token=keyword>let</token> <token=variable>p</token> = <token=struct>Point</token> { <token=property>x</token>: <token=number>5</token> };
-        <token=macro>array</token><token=macro>!</token>[<token=variable>p</token>.<token=macro>x</token>, <token=variable>p</token>.<token=function>get</token>()];
+        <token=macro>array</token><token=macro>!</token>[<token=variable>p</token>.<token=property>x</token>, <token=variable>p</token>.<token=function>get</token>()];
     }
     ")
 }

--- a/tests/e2e/semantic_tokens/declarative_macros.rs
+++ b/tests/e2e/semantic_tokens/declarative_macros.rs
@@ -89,13 +89,40 @@ fn inline_macro_content_field_and_method() {
     #[<token=decorator>generate_trait</token>]
     <token=keyword>impl</token> <token=class>PointImpl</token> <token=keyword>of</token> <token=interface>PointTrait</token> {
         <token=keyword>fn</token> <token=function>get</token>(<token=parameter>self</token>: @<token=struct>Point</token>) -> <token=type>felt252</token> {
-            <token=operator>*</token><token=variable>self</token>.x
+            <token=operator>*</token><token=variable>self</token>.<token=property>x</token>
         }
     }
 
     <token=keyword>fn</token> <token=function>main</token>() {
         <token=keyword>let</token> <token=variable>p</token> = <token=struct>Point</token> { <token=property>x</token>: <token=number>5</token> };
         <token=macro>array</token><token=macro>!</token>[<token=variable>p</token>.<token=property>x</token>, <token=variable>p</token>.<token=function>get</token>()];
+    }
+    ")
+}
+
+#[test]
+fn inline_macro_content_field_through_snapshot() {
+    test_transform_plain!(SemanticTokens, r#"
+    #[derive(Drop)]
+    struct Point {
+        x: felt252,
+    }
+
+    fn main() {
+        let p = Point { x: 5 };
+        let snapshot = @p;
+        array![*snapshot.x, @p.x];
+    }
+    "#, @r"
+    #[<token=decorator>derive</token>(<token=decorator>Drop</token>)]
+    <token=keyword>struct</token> <token=struct>Point</token> {
+        <token=variable>x</token>: <token=type>felt252</token>,
+    }
+
+    <token=keyword>fn</token> <token=function>main</token>() {
+        <token=keyword>let</token> <token=variable>p</token> = <token=struct>Point</token> { <token=property>x</token>: <token=number>5</token> };
+        <token=keyword>let</token> <token=variable>snapshot</token> = @<token=variable>p</token>;
+        <token=macro>array</token><token=macro>!</token>[<token=operator>*</token><token=variable>snapshot</token>.<token=property>x</token>, @<token=variable>p</token>.<token=property>x</token>];
     }
     ")
 }


### PR DESCRIPTION
The right-hand side of a member access like `p.x` is not a resolved item nor a
pattern, so it was left unhighlighted (or painted as the macro inside an inline
macro). Resolve it through the semantic member access expression and highlight it
as a field.