### PR TITLE
Add JSON-LD and llms.txt for AI search

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -32,6 +32,19 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      - name: Check docs llms.txt
+        run: |
+          file=.vitepress/dist/llms.txt
+          if [ ! -s "$file" ]; then
+            echo "::error::$file is missing or empty"
+            exit 1
+          fi
+          count=$(grep -cE '^- \[[^]]+\]\(https://docs\.swmansion\.com/cairols/[^)]+\)' "$file" || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::$file lists no pages"
+            exit 1
+          fi
+          echo "llms.txt lists $count pages"
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/website/.vitepress/config.mjs
+++ b/website/.vitepress/config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import { swmStructuredData, writeLlmsTxt } from "./swm-geo.mjs";
 import * as syntaxes from "./syntaxes.mjs";
 
 const base = "/cairols/";
@@ -35,6 +36,8 @@ export default defineConfig({
     lang,
     base,
 
+    transformHead: (context) => [swmStructuredData(context)],
+    buildEnd: writeLlmsTxt,
     head: [
         ["meta", { httpEquiv: "Content-Language", content: lang }],
         ["link", { rel: "icon", href: `${base}favicon.svg`, type: "image/x-icon" }],

--- a/website/.vitepress/swm-geo.mjs
+++ b/website/.vitepress/swm-geo.mjs
@@ -7,116 +7,115 @@ const SITE = "https://docs.swmansion.com";
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const decode = (value) =>
-    value
-        .replace(/&amp;/g, "&")
-        .replace(/&lt;/g, "<")
-        .replace(/&gt;/g, ">")
-        .replace(/&quot;/g, '"')
-        .replace(/&#(?:39|x27);/g, "'")
-        .trim();
+  value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#(?:39|x27);/g, "'")
+    .trim();
 
 const projectFromBase = (base) => base.replace(/\//g, "");
 
 // Same @id as swmansion.com, so engines read one company across both domains.
 export function swmStructuredData({ siteConfig }) {
-    const { base, description, title } = siteConfig.site;
-    const project = projectFromBase(base);
+  const { base, description, title } = siteConfig.site;
+  const project = projectFromBase(base);
 
-    return [
-        "script",
-        { type: "application/ld+json" },
-        JSON.stringify({
-            "@context": "https://schema.org",
-            "@graph": [
-                {
-                    "@type": "Organization",
-                    "@id": ORGANIZATION_ID,
-                    name: "Software Mansion",
-                    url: "https://swmansion.com",
-                    sameAs: [
-                        "https://github.com/software-mansion",
-                        "https://www.linkedin.com/company/software-mansion/",
-                        "https://twitter.com/swmansion",
-                        "https://www.youtube.com/c/SoftwareMansion",
-                    ],
-                },
-                {
-                    "@type": "SoftwareSourceCode",
-                    name: title,
-                    ...(description ? { description } : {}),
-                    ...(project
-                        ? {
-                              codeRepository: `https://github.com/software-mansion/${project}`,
-                          }
-                        : {}),
-                    author: { "@id": ORGANIZATION_ID },
-                    maintainer: { "@id": ORGANIZATION_ID },
-                },
-            ],
-        }),
-    ];
+  return [
+    "script",
+    { type: "application/ld+json" },
+    JSON.stringify({
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": ORGANIZATION_ID,
+          name: "Software Mansion",
+          url: "https://swmansion.com",
+          sameAs: [
+            "https://github.com/software-mansion",
+            "https://www.linkedin.com/company/software-mansion/",
+            "https://twitter.com/swmansion",
+            "https://www.youtube.com/c/SoftwareMansion",
+          ],
+        },
+        {
+          "@type": "SoftwareSourceCode",
+          name: title,
+          ...(description ? { description } : {}),
+          ...(project
+            ? {
+                codeRepository: `https://github.com/software-mansion/${project}`,
+              }
+            : {}),
+          author: { "@id": ORGANIZATION_ID },
+          maintainer: { "@id": ORGANIZATION_ID },
+        },
+      ],
+    }),
+  ];
 }
 
 function collectHtml(dir, root = dir, found = []) {
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) collectHtml(full, root, found);
-        else if (entry.name.endsWith(".html") && entry.name !== "404.html")
-            found.push(path.relative(root, full));
-    }
-    return found;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectHtml(full, root, found);
+    else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+      found.push(path.relative(root, full));
+  }
+  return found;
 }
 
 export function buildLlmsTxt({ base, description, files, readFile, title }) {
-    const entries = [];
+  const entries = [];
 
-    for (const file of files) {
-        const html = readFile(file);
-        const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
-        const name = decode(raw).replace(
-            new RegExp(`\\s*\\|\\s*${escapeRegExp(title)}$`),
-            "",
-        );
-        if (!name) continue;
+  for (const file of files) {
+    const html = readFile(file);
+    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+    const name = decode(raw).replace(
+      new RegExp(`\\s*\\|\\s*${escapeRegExp(title)}$`),
+      "",
+    );
+    if (!name) continue;
 
-        const detail = decode(
-            /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(
-                html,
-            )?.[1] ?? "",
-        );
-        const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
-        entries.push(
-            `- [${name}](${SITE}${base}${route})${detail ? `: ${detail}` : ""}`,
-        );
-    }
-
-    const lines = [`# ${title}`];
-    if (description) lines.push("", `> ${description}`);
-    if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
-    lines.push(
-        "",
-        "## About",
-        "",
-        `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
+    const detail = decode(
+      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ??
         "",
     );
+    const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
+    entries.push(
+      `- [${name}](${SITE}${base}${route})${detail ? `: ${detail}` : ""}`,
+    );
+  }
 
-    return lines.join("\n");
+  const lines = [`# ${title}`];
+  if (description) lines.push("", `> ${description}`);
+  if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+  lines.push(
+    "",
+    "## About",
+    "",
+    `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
+    "",
+  );
+
+  return lines.join("\n");
 }
 
 export async function writeLlmsTxt(siteConfig) {
-    const { outDir, site } = siteConfig;
-    const files = collectHtml(outDir);
+  const { outDir, site } = siteConfig;
+  const files = collectHtml(outDir);
 
-    await fs.promises.writeFile(
-        path.join(outDir, "llms.txt"),
-        buildLlmsTxt({
-            base: site.base,
-            description: site.description,
-            files,
-            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
-            title: site.title,
-        }),
-        "utf8",
-    );
+  await fs.promises.writeFile(
+    path.join(outDir, "llms.txt"),
+    buildLlmsTxt({
+      base: site.base,
+      description: site.description,
+      files,
+      readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+      title: site.title,
+    }),
+    "utf8",
+  );
 }

--- a/website/.vitepress/swm-geo.mjs
+++ b/website/.vitepress/swm-geo.mjs
@@ -7,115 +7,109 @@ const SITE = "https://docs.swmansion.com";
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const decode = (value) =>
-  value
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#(?:39|x27);/g, "'")
-    .trim();
+    value
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#(?:39|x27);/g, "'")
+        .trim();
 
 const projectFromBase = (base) => base.replace(/\//g, "");
 
 // Same @id as swmansion.com, so engines read one company across both domains.
 export function swmStructuredData({ siteConfig }) {
-  const { base, description, title } = siteConfig.site;
-  const project = projectFromBase(base);
+    const { base, description, title } = siteConfig.site;
+    const project = projectFromBase(base);
 
-  return [
-    "script",
-    { type: "application/ld+json" },
-    JSON.stringify({
-      "@context": "https://schema.org",
-      "@graph": [
-        {
-          "@type": "Organization",
-          "@id": ORGANIZATION_ID,
-          name: "Software Mansion",
-          url: "https://swmansion.com",
-          sameAs: [
-            "https://github.com/software-mansion",
-            "https://www.linkedin.com/company/software-mansion/",
-            "https://twitter.com/swmansion",
-            "https://www.youtube.com/c/SoftwareMansion",
-          ],
-        },
-        {
-          "@type": "SoftwareSourceCode",
-          name: title,
-          ...(description ? { description } : {}),
-          ...(project
-            ? {
-                codeRepository: `https://github.com/software-mansion/${project}`,
-              }
-            : {}),
-          author: { "@id": ORGANIZATION_ID },
-          maintainer: { "@id": ORGANIZATION_ID },
-        },
-      ],
-    }),
-  ];
+    return [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+                {
+                    "@type": "Organization",
+                    "@id": ORGANIZATION_ID,
+                    name: "Software Mansion",
+                    url: "https://swmansion.com",
+                    sameAs: [
+                        "https://github.com/software-mansion",
+                        "https://www.linkedin.com/company/software-mansion/",
+                        "https://twitter.com/swmansion",
+                        "https://www.youtube.com/c/SoftwareMansion",
+                    ],
+                },
+                {
+                    "@type": "SoftwareSourceCode",
+                    name: title,
+                    ...(description ? { description } : {}),
+                    ...(project
+                        ? {
+                              codeRepository: `https://github.com/software-mansion/${project}`,
+                          }
+                        : {}),
+                    author: { "@id": ORGANIZATION_ID },
+                    maintainer: { "@id": ORGANIZATION_ID },
+                },
+            ],
+        }),
+    ];
 }
 
 function collectHtml(dir, root = dir, found = []) {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) collectHtml(full, root, found);
-    else if (entry.name.endsWith(".html") && entry.name !== "404.html")
-      found.push(path.relative(root, full));
-  }
-  return found;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectHtml(full, root, found);
+        else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+            found.push(path.relative(root, full));
+    }
+    return found;
 }
 
 export function buildLlmsTxt({ base, description, files, readFile, title }) {
-  const entries = [];
+    const entries = [];
 
-  for (const file of files) {
-    const html = readFile(file);
-    const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
-    const name = decode(raw).replace(
-      new RegExp(`\\s*\\|\\s*${escapeRegExp(title)}$`),
-      "",
-    );
-    if (!name) continue;
+    for (const file of files) {
+        const html = readFile(file);
+        const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+        const name = decode(raw).replace(new RegExp(`\\s*\\|\\s*${escapeRegExp(title)}$`), "");
+        if (!name) continue;
 
-    const detail = decode(
-      /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ??
+        const detail = decode(
+            /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(html)?.[1] ?? "",
+        );
+        const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
+        entries.push(`- [${name}](${SITE}${base}${route})${detail ? `: ${detail}` : ""}`);
+    }
+
+    const lines = [`# ${title}`];
+    if (description) lines.push("", `> ${description}`);
+    if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+    lines.push(
+        "",
+        "## About",
+        "",
+        `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
         "",
     );
-    const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
-    entries.push(
-      `- [${name}](${SITE}${base}${route})${detail ? `: ${detail}` : ""}`,
-    );
-  }
 
-  const lines = [`# ${title}`];
-  if (description) lines.push("", `> ${description}`);
-  if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
-  lines.push(
-    "",
-    "## About",
-    "",
-    `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
-    "",
-  );
-
-  return lines.join("\n");
+    return lines.join("\n");
 }
 
 export async function writeLlmsTxt(siteConfig) {
-  const { outDir, site } = siteConfig;
-  const files = collectHtml(outDir);
+    const { outDir, site } = siteConfig;
+    const files = collectHtml(outDir);
 
-  await fs.promises.writeFile(
-    path.join(outDir, "llms.txt"),
-    buildLlmsTxt({
-      base: site.base,
-      description: site.description,
-      files,
-      readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
-      title: site.title,
-    }),
-    "utf8",
-  );
+    await fs.promises.writeFile(
+        path.join(outDir, "llms.txt"),
+        buildLlmsTxt({
+            base: site.base,
+            description: site.description,
+            files,
+            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+            title: site.title,
+        }),
+        "utf8",
+    );
 }

--- a/website/.vitepress/swm-geo.mjs
+++ b/website/.vitepress/swm-geo.mjs
@@ -1,0 +1,122 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const ORGANIZATION_ID = "https://swmansion.com/#organization";
+const SITE = "https://docs.swmansion.com";
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const decode = (value) =>
+    value
+        .replace(/&amp;/g, "&")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&#(?:39|x27);/g, "'")
+        .trim();
+
+const projectFromBase = (base) => base.replace(/\//g, "");
+
+// Same @id as swmansion.com, so engines read one company across both domains.
+export function swmStructuredData({ siteConfig }) {
+    const { base, description, title } = siteConfig.site;
+    const project = projectFromBase(base);
+
+    return [
+        "script",
+        { type: "application/ld+json" },
+        JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+                {
+                    "@type": "Organization",
+                    "@id": ORGANIZATION_ID,
+                    name: "Software Mansion",
+                    url: "https://swmansion.com",
+                    sameAs: [
+                        "https://github.com/software-mansion",
+                        "https://www.linkedin.com/company/software-mansion/",
+                        "https://twitter.com/swmansion",
+                        "https://www.youtube.com/c/SoftwareMansion",
+                    ],
+                },
+                {
+                    "@type": "SoftwareSourceCode",
+                    name: title,
+                    ...(description ? { description } : {}),
+                    ...(project
+                        ? {
+                              codeRepository: `https://github.com/software-mansion/${project}`,
+                          }
+                        : {}),
+                    author: { "@id": ORGANIZATION_ID },
+                    maintainer: { "@id": ORGANIZATION_ID },
+                },
+            ],
+        }),
+    ];
+}
+
+function collectHtml(dir, root = dir, found = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) collectHtml(full, root, found);
+        else if (entry.name.endsWith(".html") && entry.name !== "404.html")
+            found.push(path.relative(root, full));
+    }
+    return found;
+}
+
+export function buildLlmsTxt({ base, description, files, readFile, title }) {
+    const entries = [];
+
+    for (const file of files) {
+        const html = readFile(file);
+        const raw = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html)?.[1] ?? "";
+        const name = decode(raw).replace(
+            new RegExp(`\\s*\\|\\s*${escapeRegExp(title)}$`),
+            "",
+        );
+        if (!name) continue;
+
+        const detail = decode(
+            /<meta[^>]+name="description"[^>]+content="([^"]*)"/i.exec(
+                html,
+            )?.[1] ?? "",
+        );
+        const route = file.replace(/index\.html$/, "").replace(/\.html$/, "");
+        entries.push(
+            `- [${name}](${SITE}${base}${route})${detail ? `: ${detail}` : ""}`,
+        );
+    }
+
+    const lines = [`# ${title}`];
+    if (description) lines.push("", `> ${description}`);
+    if (entries.length) lines.push("", "## Documentation", "", ...entries.sort());
+    lines.push(
+        "",
+        "## About",
+        "",
+        `- [Software Mansion](https://swmansion.com): maintainer of ${title}`,
+        "",
+    );
+
+    return lines.join("\n");
+}
+
+export async function writeLlmsTxt(siteConfig) {
+    const { outDir, site } = siteConfig;
+    const files = collectHtml(outDir);
+
+    await fs.promises.writeFile(
+        path.join(outDir, "llms.txt"),
+        buildLlmsTxt({
+            base: site.base,
+            description: site.description,
+            files,
+            readFile: (file) => fs.readFileSync(path.join(outDir, file), "utf8"),
+            title: site.title,
+        }),
+        "utf8",
+    );
+}


### PR DESCRIPTION
Two SEO changes for the website. Nothing changes the rendered page.

- **JSON-LD** via `transformHead`: `Organization` with the same `@id` as swmansion.com, plus `SoftwareSourceCode`, both derived from `siteConfig`. The identical `@id` is what makes engines read this site and swmansion.com as one entity instead of two unrelated ones.
- **`llms.txt`** via `buildEnd`, written from the pages VitePress just built — no new dependency. The workflow fails if the file is missing or lists nothing.

Both live in `website/.vitepress/swm-geo.mjs`; the config gains an import and two lines. The same change is going out across the docs repos; reference: software-mansion/react-native-reanimated#10332.

**Check:** this workflow only runs on push and dispatch, so the new step could not run on this PR. It sits before the Pages upload, so a broken `llms.txt` blocks the deploy rather than shipping silently. The equivalent step is green in the Docusaurus repos, listing 25 to 90 pages.