### PR TITLE
Fix semantic highlighting for locals shadowing crate names

### DIFF
--- a/src/ide/semantic_highlighting/token_kind.rs
+++ b/src/ide/semantic_highlighting/token_kind.rs
@@ -89,11 +89,14 @@ impl SemanticTokenKind {
                     continue;
                 };
                 for lookup_item_id in lookup_items {
-                    if let Some(kind) = Self::from_resultant(db, *resultant, *lookup_item_id) {
+                    // A local binding can shadow a crate or module with the same name. Prefer the
+                    // function body's pattern lookup before the resolved item so the binding is
+                    // highlighted as a variable rather than as the shadowed namespace.
+                    if let Some(kind) = Self::from_expr_path(db, *resultant, *lookup_item_id) {
                         return Some(kind);
                     }
 
-                    if let Some(kind) = Self::from_expr_path(db, *resultant, *lookup_item_id) {
+                    if let Some(kind) = Self::from_resultant(db, *resultant, *lookup_item_id) {
                         return Some(kind);
                     }
 

--- a/tests/e2e/semantic_tokens/complex.rs
+++ b/tests/e2e/semantic_tokens/complex.rs
@@ -60,6 +60,23 @@ fn complex() {
 }
 
 #[test]
+fn local_variable_shadows_crate_name() {
+    test_transform_plain!(SemanticTokens, r#"
+    #[test]
+    fn test() {
+        let snforge_std = 10;
+        assert(snforge_std == 10, '');
+    }
+    "#, @r#"
+    #[<token=decorator>test</token>]
+    <token=keyword>fn</token> <token=function>test</token>() {
+        <token=keyword>let</token> <token=variable>snforge_std</token> = <token=number>10</token>;
+        <token=function>assert</token>(<token=variable>snforge_std</token> <token=operator>==</token> <token=number>10</token>, <token=string>''</token>);
+    }
+    "#)
+}
+
+#[test]
 fn multiline() {
     test_transform_plain!(SemanticTokens, r#"
     fn main() {


### PR DESCRIPTION
## Summary
- prioritize function-local pattern lookup before crate/module resolution during semantic highlighting
- add regression coverage for a local `snforge_std` binding shadowing the crate name

This keeps the local declaration and its use classified as variables instead of namespaces.

## Verification
- added an end-to-end semantic-token regression test
- `git diff --check`
- the Rust test suite was not run locally because this environment has no Rust toolchain; CI should execute the new regression

Closes #1302