### PR TITLE
Fix stuck analysis spinner

### DIFF
--- a/src/lang/db/swapper.rs
+++ b/src/lang/db/swapper.rs
@@ -50,8 +50,8 @@ pub struct AnalysisDatabaseSwapper {
     mutations_since_last_replace: u64,
     db_replace_min_mutations: u64,
     analysis_event_sender: Sender<AnalysisEvent>,
-    /// Revision of the database produced by the last swap.
-    ///
+    /// Revision of the database produced by the last swap
+    /// (i.e.. the revision of the freshly swapped database).
     /// Used to tell whether anything has actually been written since then, which decides both
     /// whether a new swap can reclaim anything and whether the scheduler will run the
     /// `sync_mut_task` hooks for it.
@@ -73,7 +73,12 @@ impl AnalysisDatabaseSwapper {
     }
 
     /// Swaps the database, triggered by the inactivity monitor.
-    pub fn swap_on_inactivity(&mut self, db: &mut AnalysisDatabase, open_files: &HashSet<Url>) {
+    /// Swap will only be performed if the database has been mutated since the last swap.
+    pub fn maybe_swap_on_inactivity(
+        &mut self,
+        db: &mut AnalysisDatabase,
+        open_files: &HashSet<Url>,
+    ) {
         if self.last_swap_revision == Some(current_revision(db)) {
             trace!("skipping inactivity swap: nothing was written since the last swap");
             return;

--- a/src/lang/db/swapper.rs
+++ b/src/lang/db/swapper.rs
@@ -7,6 +7,8 @@ use std::time::{Duration, SystemTime};
 
 use crossbeam::channel::{Receiver, RecvTimeoutError, Sender, TrySendError};
 use lsp_types::Url;
+use salsa::Revision;
+use salsa::plumbing::current_revision;
 use tracing::{error, trace, warn};
 
 use crate::env_config;
@@ -48,6 +50,12 @@ pub struct AnalysisDatabaseSwapper {
     mutations_since_last_replace: u64,
     db_replace_min_mutations: u64,
     analysis_event_sender: Sender<AnalysisEvent>,
+    /// Revision of the database produced by the last swap.
+    ///
+    /// Used to tell whether anything has actually been written since then, which decides both
+    /// whether a new swap can reclaim anything and whether the scheduler will run the
+    /// `sync_mut_task` hooks for it.
+    last_swap_revision: Option<Revision>,
 }
 
 impl AnalysisDatabaseSwapper {
@@ -56,6 +64,7 @@ impl AnalysisDatabaseSwapper {
             mutations_since_last_replace: 0,
             db_replace_min_mutations: env_config::db_replace_mutations(),
             analysis_event_sender,
+            last_swap_revision: None,
         }
     }
 
@@ -63,14 +72,20 @@ impl AnalysisDatabaseSwapper {
         self.mutations_since_last_replace += 1;
     }
 
-    /// Swaps the database unconditionally, triggered by the inactivity monitor.
+    /// Swaps the database, triggered by the inactivity monitor.
     pub fn swap_on_inactivity(&mut self, db: &mut AnalysisDatabase, open_files: &HashSet<Url>) {
+        if self.last_swap_revision == Some(current_revision(db)) {
+            trace!("skipping inactivity swap: nothing was written since the last swap");
+            return;
+        }
+
         if let Err(err) = self.analysis_event_sender.send(AnalysisEvent::DatabaseSwap) {
             error!("Could not send swap status: {err:?}");
         }
 
         self.swap(db, open_files);
         self.mutations_since_last_replace = 0;
+        self.last_swap_revision = Some(current_revision(db));
 
         trace!("Database swapped due to inactivity");
     }
@@ -89,6 +104,7 @@ impl AnalysisDatabaseSwapper {
 
         self.swap(db, open_files);
         self.mutations_since_last_replace = 0;
+        self.last_swap_revision = Some(current_revision(db));
 
         trace!("Database swapped - {reason}");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,7 +389,7 @@ impl Backend {
                             .lock()
                             .expect("should be able to acquire the MetaState");
                         ms.inactivity_monitor.notify_swap_triggered();
-                        ms.db_swapper.swap_on_inactivity(
+                        ms.db_swapper.maybe_swap_on_inactivity(
                             &mut state.db,
                             &state.open_files,
                         );


### PR DESCRIPTION
Closes #1365

## Problem

After a few minutes of inactivity the analysis spinner appears and never goes
away. It only clears once the user types something.

## Cause

`swap_on_inactivity` always sends `AnalysisEvent::DatabaseSwap`, which turns the
spinner **on**. The spinner is turned **off** only when a diagnostics tick
finishes, and ticks are started by `refresh_diagnostics` - a `sync_mut_task`
hook that the scheduler runs only if the task changed the database revision.

A swap *replaces* the database, so the before/after revisions come from
unrelated Salsa runtimes. When nothing has been written since the previous swap,
`migrate_to_fresh_database` rebuilds an identical database with an identical
revision, the gate evaluates to `false`, and the hooks - including the
diagnostics refresh - are skipped. The spinner is switched on unconditionally
while the only thing that can switch it off sits behind a gate the swap fails.

This is why the *second* consecutive idle swap is the one that wedges it: the
first follows real edits, so its revision does differ.